### PR TITLE
Use coveragerc from source, even when building outside.

### DIFF
--- a/flocker_bb/builders/flocker.py
+++ b/flocker_bb/builders/flocker.py
@@ -106,12 +106,13 @@ def _flockerCoverage():
                 '    flocker',
                 '    /*/site-packages/flocker',
                 '']),
-            '.coveragerc',
+            '.coveragerc-combine',
             name="download-coveragerc"),
         ShellCommand(
             command=[
                 Interpolate(path.join(VIRTUALENV_DIR, "bin/coverage")),
                 'combine',
+                '--rcfile=.coveragerc-combine',
                 ],
             name='rewrite-coverage',
             description=[b'Rewriting', b'coverage'],


### PR DESCRIPTION
Refs #6.

This is needed for the effect of ClusterHQ/flocker#623 to be reflected on the buildbot.
