### PR TITLE
[FLOC-1227] Propagate merge versions across triggers.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,9 @@ FROM fedora:20
 #ADD https://copr.fedoraproject.org/coprs/tomprince/hybridlogic/repo/fedora-20-x86_64/tomprince-hybridlogic-fedora-20-x86_64.repo /etc/yum.repos.d/
 ADD tomprince-hybridlogic-fedora-20-x86_64.repo /etc/yum.repos.d/
 #RUN yum upgrade -y
-RUN yum install -y python-devel python-pip gcc libffi-devel openssl-devel git s3cmd
+RUN yum install -y python-devel python-pip gcc libffi-devel openssl-devel git s3cmd dpkg-dev createrepo_c
 RUN ["pip", "install", "buildbot==0.8.10", "txgithub==15.0.0", "eliot", "apache-libcloud", "service_identity", "machinist"]
 
-RUN yum install -y dpkg-dev createrepo_c
 
 
 ADD buildbot.tac /srv/buildmaster/

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,8 @@ ADD tomprince-hybridlogic-fedora-20-x86_64.repo /etc/yum.repos.d/
 RUN yum install -y python-devel python-pip gcc libffi-devel openssl-devel git s3cmd
 RUN ["pip", "install", "buildbot==0.8.10", "txgithub==15.0.0", "eliot", "apache-libcloud", "service_identity", "machinist"]
 
+RUN yum install -y dpkg-dev createrepo_c
+
 
 ADD buildbot.tac /srv/buildmaster/
 ADD public_html /srv/buildmaster/public_html

--- a/flocker_bb/boxes.py
+++ b/flocker_bb/boxes.py
@@ -149,7 +149,7 @@ class FlockerWebStatus(html.WebStatus):
         html.WebStatus.setupSite(self)
         resource = self.site.resource
 
-        docdevPath = os.path.join(self.master.basedir, "private_html", "docs")
+        docdevPath = os.path.join(self.master.basedir, "doc-dev")
         docdev = File(docdevPath)
 
         File.contentTypes[".py,cover"] = "text/plain"

--- a/flocker_bb/builders/flocker.py
+++ b/flocker_bb/builders/flocker.py
@@ -31,7 +31,7 @@ buildNumber = Interpolate("flocker-%(prop:buildnumber)s")
 
 def _result(kind, prefix, descriminator=buildNumber):
     return Interpolate(
-        b"%(kw:prefix)s%(kw:kind)s/%(kw:descriminator)s/%(kw:build)s",
+        b"%(kw:prefix)s%(kw:kind)s/%(kw:branch)s/%(kw:descriminator)s",
         branch=flockerBranch, descriminator=descriminator,
         kind=kind, prefix=prefix)
 

--- a/flocker_bb/builders/flocker.py
+++ b/flocker_bb/builders/flocker.py
@@ -19,29 +19,14 @@ from ..steps import (
     GITHUB,
     TWISTED_GIT,
     pip,
-    flockerBranch,
-    isMasterBranch, isReleaseBranch
+    isMasterBranch, isReleaseBranch,
+    resultPath, resultURL,
     )
 
 # This is where temporary files associated with a build will be dumped.
 TMPDIR = Interpolate(b"%(prop:workdir)s/tmp-%(prop:buildnumber)s")
 
 buildNumber = Interpolate("flocker-%(prop:buildnumber)s")
-
-
-def _result(kind, prefix, descriminator=buildNumber):
-    return Interpolate(
-        b"%(kw:prefix)s%(kw:kind)s/%(kw:branch)s/%(kw:descriminator)s",
-        branch=flockerBranch, descriminator=descriminator,
-        kind=kind, prefix=prefix)
-
-
-def resultPath(kind, descriminator=buildNumber):
-    return _result(kind, prefix="private_html/", descriminator=descriminator)
-
-
-def resultURL(kind, descriminator=buildNumber):
-    return _result(kind, prefix="/results/", descriminator=descriminator)
 
 
 def getFlockerFactory(python):
@@ -338,7 +323,7 @@ def makeInternalDocsFactory():
         descriptionDone=["link", "release", "documentation"],
         command=[
             "ln", '-nsf',
-            _result('docs', prefix=''),
+            resultPath('docs'),
             'docs',
             ],
         path="private_html",

--- a/flocker_bb/builders/flocker.py
+++ b/flocker_bb/builders/flocker.py
@@ -7,7 +7,7 @@ from buildbot.steps.python import Sphinx
 from buildbot.steps.transfer import DirectoryUpload, StringDownload
 from buildbot.steps.master import MasterShellCommand
 from buildbot.steps.source.git import Git
-from buildbot.process.properties import Interpolate
+from buildbot.process.properties import Interpolate, Property
 from buildbot.steps.trigger import Trigger
 from buildbot.config import error
 
@@ -432,6 +432,9 @@ def makeOmnibusFactory(distribution, triggerSchedulers=()):
         factory.addStep(Trigger(
             name='trigger/built-rpms',
             schedulerNames=triggerSchedulers,
+            set_properties={
+                'merge_target': Property('lint_revision')
+            },
             updateSourceStamp=True,
             waitForFinish=False,
             ))

--- a/flocker_bb/builders/flocker.py
+++ b/flocker_bb/builders/flocker.py
@@ -322,9 +322,8 @@ def makeInternalDocsFactory():
         command=[
             "ln", '-nsf',
             resultPath('docs'),
-            'docs',
+            'doc-dev',
             ],
-        path="private_html",
         doStepIf=isMasterBranch('flocker'),
         ))
     factory.addStep(MasterShellCommand(

--- a/flocker_bb/builders/flocker.py
+++ b/flocker_bb/builders/flocker.py
@@ -26,8 +26,6 @@ from ..steps import (
 # This is where temporary files associated with a build will be dumped.
 TMPDIR = Interpolate(b"%(prop:workdir)s/tmp-%(prop:buildnumber)s")
 
-buildNumber = Interpolate("flocker-%(prop:buildnumber)s")
-
 
 def getFlockerFactory(python):
     factory = getFactory("flocker", useSubmodules=False, mergeForward=True)

--- a/flocker_bb/builders/flocker.py
+++ b/flocker_bb/builders/flocker.py
@@ -408,12 +408,12 @@ def makeOmnibusFactory(distribution, triggerSchedulers=()):
         descriptionDone=['build', 'package'],
         haltOnFailure=True))
 
-    repository_path = resultPath('omnibus', descriminator=distribution)
+    repository_path = resultPath('omnibus', discriminator=distribution)
 
     factory.addStep(DirectoryUpload(
         'repo',
         repository_path,
-        url=resultURL('omnibus', descriminator=distribution),
+        url=resultURL('omnibus', discriminator=distribution),
         name="upload-repo",
     ))
     factory.addSteps(createRepository(distribution, repository_path))
@@ -422,6 +422,9 @@ def makeOmnibusFactory(distribution, triggerSchedulers=()):
             name='trigger/built-rpms',
             schedulerNames=triggerSchedulers,
             set_properties={
+                # lint_revision is the commit that was merged against,
+                # if we merged forward, so have the triggered build
+                # merge against it as well.
                 'merge_target': Property('lint_revision')
             },
             updateSourceStamp=True,

--- a/flocker_bb/builders/flocker.py
+++ b/flocker_bb/builders/flocker.py
@@ -374,7 +374,7 @@ def createRepository(distribution, repository_path):
             name='build-repo-metadata',
             description=["building", "repo", "metadata"],
             descriptionDone=["build", "repo", "metadata"],
-            command=["createrepo_c", "repo"],
+            command=["createrepo_c", "."],
             path=repository_path,
             haltOnFailure=True))
     elif flavour in ("ubuntu", "debian"):

--- a/flocker_bb/builders/flocker_vagrant.py
+++ b/flocker_bb/builders/flocker_vagrant.py
@@ -173,6 +173,9 @@ def buildTutorialBox():
     factory.addStep(Trigger(
         name='trigger-vagrant-tests',
         schedulerNames=['trigger/built-vagrant-box/flocker-tutorial'],
+        set_properties={
+            'merge_target': Property('lint_revision')
+        },
         updateSourceStamp=True,
         waitForFinish=False,
         ))

--- a/flocker_bb/builders/flocker_vagrant.py
+++ b/flocker_bb/builders/flocker_vagrant.py
@@ -9,7 +9,8 @@ from ..steps import (
     getFactory,
     GITHUB,
     buildbotURL,
-    MasterWriteFile, asJSON
+    MasterWriteFile, asJSON,
+    flockerBranch,
     )
 
 # FIXME
@@ -17,8 +18,6 @@ from flocker_bb.builders.flocker import installDependencies, _flockerTests
 
 # This is where temporary files associated with a build will be dumped.
 TMPDIR = Interpolate(b"%(prop:workdir)s/tmp-%(prop:buildnumber)s")
-
-flockerBranch = Interpolate("%(src:flocker:branch)s")
 
 
 def dotted_version(version):

--- a/flocker_bb/builders/flocker_vagrant.py
+++ b/flocker_bb/builders/flocker_vagrant.py
@@ -80,7 +80,7 @@ def buildVagrantBox(box, add=True):
         name='write-base-box-metadata',
         description=['writing', 'base', box, 'box', 'metadata'],
         descriptionDone=['write', 'base', box, 'box', 'metadata'],
-        path=resultPath('vagrant', descrimintaor="flocker-%s.json" % box),
+        path=resultPath('vagrant', descriminator="flocker-%s.json" % box),
         content=asJSON({
             "name": "clusterhq/flocker-%s" % (box,),
             "description": "Test clusterhq/flocker-%s box." % (box,),
@@ -97,7 +97,7 @@ def buildVagrantBox(box, add=True):
         }),
         urls={
             Interpolate('%(kw:box)s box', box=box):
-            resultURL('vagrant', descrimintaor="flocker-%s.json" % box),
+            resultURL('vagrant', descriminator="flocker-%s.json" % box),
         }
     ))
 

--- a/flocker_bb/builders/flocker_vagrant.py
+++ b/flocker_bb/builders/flocker_vagrant.py
@@ -80,7 +80,7 @@ def buildVagrantBox(box, add=True):
         name='write-base-box-metadata',
         description=['writing', 'base', box, 'box', 'metadata'],
         descriptionDone=['write', 'base', box, 'box', 'metadata'],
-        path=resultPath('vagrant', descriminator="flocker-%s.json" % box),
+        path=resultPath('vagrant', discriminator="flocker-%s.json" % box),
         content=asJSON({
             "name": "clusterhq/flocker-%s" % (box,),
             "description": "Test clusterhq/flocker-%s box." % (box,),
@@ -97,7 +97,7 @@ def buildVagrantBox(box, add=True):
         }),
         urls={
             Interpolate('%(kw:box)s box', box=box):
-            resultURL('vagrant', descriminator="flocker-%s.json" % box),
+            resultURL('vagrant', discriminator="flocker-%s.json" % box),
         }
     ))
 
@@ -168,6 +168,9 @@ def buildTutorialBox():
         name='trigger-vagrant-tests',
         schedulerNames=['trigger/built-vagrant-box/flocker-tutorial'],
         set_properties={
+            # lint_revision is the commit that was merged against,
+            # if we merged forward, so have the triggered build
+            # merge against it as well.
             'merge_target': Property('lint_revision')
         },
         updateSourceStamp=True,

--- a/flocker_bb/builders/flocker_vagrant.py
+++ b/flocker_bb/builders/flocker_vagrant.py
@@ -17,9 +17,6 @@ from ..steps import (
 # FIXME
 from flocker_bb.builders.flocker import installDependencies, _flockerTests
 
-# This is where temporary files associated with a build will be dumped.
-TMPDIR = Interpolate(b"%(prop:workdir)s/tmp-%(prop:buildnumber)s")
-
 
 def dotted_version(version):
     @renderer

--- a/flocker_bb/builders/flocker_vagrant.py
+++ b/flocker_bb/builders/flocker_vagrant.py
@@ -11,6 +11,7 @@ from ..steps import (
     buildbotURL,
     MasterWriteFile, asJSON,
     flockerBranch,
+    resultPath, resultURL
     )
 
 # FIXME
@@ -82,9 +83,7 @@ def buildVagrantBox(box, add=True):
         name='write-base-box-metadata',
         description=['writing', 'base', box, 'box', 'metadata'],
         descriptionDone=['write', 'base', box, 'box', 'metadata'],
-        path=Interpolate(
-            b"private_html/vagrant/%(kw:branch)s/flocker-%(kw:box)s.json",
-            branch=flockerBranch, box=box),
+        path=resultPath('vagrant', descrimintaor="flocker-%s.json" % box),
         content=asJSON({
             "name": "clusterhq/flocker-%s" % (box,),
             "description": "Test clusterhq/flocker-%s box." % (box,),
@@ -101,8 +100,7 @@ def buildVagrantBox(box, add=True):
         }),
         urls={
             Interpolate('%(kw:box)s box', box=box):
-            Interpolate(b"/results/vagrant/%(kw:branch)s/flocker-%(kw:box)s.json",  # noqa
-                branch=flockerBranch, box=box),
+            resultURL('vagrant', descrimintaor="flocker-%s.json" % box),
         }
     ))
 

--- a/flocker_bb/monkeypatch.py
+++ b/flocker_bb/monkeypatch.py
@@ -77,3 +77,5 @@ def apply_patches():
     BotMaster.maybeStartBuildsForSlave = botmaster_maybeStartBuildsForSlave
     from buildbot.process.slavebuilder import SlaveBuilder
     SlaveBuilder.buildStarted = slavebuilder_buildStarted
+    from buildbot.steps.master import MasterShellCommand
+    MasterShellCommand.renderables += ['path']

--- a/flocker_bb/steps.py
+++ b/flocker_bb/steps.py
@@ -40,6 +40,8 @@ def _result(kind, prefix, discriminator=buildNumber):
         d.addCallback(
             lambda args:
             FilePath(args[0]).descendant(args[1:]).path)
+        return d
+    return render
 
 resultPath = partial(_result, prefix="private_html")
 resultURL = partial(_result, prefix="/results/")

--- a/flocker_bb/steps.py
+++ b/flocker_bb/steps.py
@@ -209,7 +209,7 @@ class MergeForward(Source):
             d.addCallback(lambda _: self._fetch(merge_branch))
             d.addCallback(lambda _: self._getCommitDate())
             d.addCallback(self._merge)
-            d.addCallback(lambda _: self._getMergeBase())
+            d.addCallback(self._getMergeBase)
 
         d.addCallback(self._setLintVersion)
         d.addCallback(lambda _: SUCCESS)
@@ -233,16 +233,19 @@ class MergeForward(Source):
             'GIT_AUTHOR_DATE': date.strip(),
             'GIT_COMMITTER_DATE': date.strip(),
         })
-        return self._dovccmd(['merge',
-                              '--no-ff', '--no-stat',
-                              'FETCH_HEAD'])
+        merge_target = self.getProperty('merge_target', 'FETCH_HEAD')
+        d = self._dovccmd(['merge',
+                           '--no-ff', '--no-stat',
+                           merge_target])
+        d.addCallback(lambda _: merge_target)
+        return d
 
     def _getPreviousVersion(self):
         return self._dovccmd(['rev-parse', 'HEAD~1'],
                              collectStdout=True)
 
-    def _getMergeBase(self):
-        return self._dovccmd(['merge-base', 'HEAD', 'FETCH_HEAD'],
+    def _getMergeBase(self, merge_target):
+        return self._dovccmd(['rev-parse', merge_target],
                              collectStdout=True)
 
     def _setLintVersion(self, version):

--- a/flocker_bb/steps.py
+++ b/flocker_bb/steps.py
@@ -28,15 +28,15 @@ flockerBranch = Interpolate("%(src:flocker:branch)s")
 buildNumber = Interpolate("%(prop:buildNumber)s")
 
 
-def _result(kind, prefix, descriminator=buildNumber):
+def _result(kind, prefix, discriminator=buildNumber):
     """
-    Build a path to resultss.
+    Build a path to results.
     """
     @renderer
     def render(build):
         d = defer.gatherResults(
             map(build.render,
-                [prefix, kind, flockerBranch, descriminator]))
+                [prefix, kind, flockerBranch, discriminator]))
         d.addCallback(
             lambda args:
             FilePath(args[0]).descendant(args[1:]).path)
@@ -255,6 +255,8 @@ class MergeForward(Source):
             'GIT_AUTHOR_DATE': date.strip(),
             'GIT_COMMITTER_DATE': date.strip(),
         })
+        # Merge against the requested commit (if this is a triggered build).
+        # Otherwise, merge against the tip of the merge branch.
         merge_target = self.getProperty('merge_target', 'FETCH_HEAD')
         d = self._dovccmd(['merge',
                            '--no-ff', '--no-stat',

--- a/flocker_bb/steps.py
+++ b/flocker_bb/steps.py
@@ -25,7 +25,7 @@ TWISTED_GIT = b'https://github.com/twisted/twisted'
 
 flockerBranch = Interpolate("%(src:flocker:branch)s")
 
-buildNumber = Interpolate("%(buildNumber)s")
+buildNumber = Interpolate("%(prop:buildNumber)s")
 
 
 def _result(kind, prefix, descriminator=buildNumber):

--- a/flocker_bb/steps.py
+++ b/flocker_bb/steps.py
@@ -22,6 +22,8 @@ GITHUB = b"https://github.com/ClusterHQ"
 
 TWISTED_GIT = b'https://github.com/twisted/twisted'
 
+flockerBranch = Interpolate("%(src:flocker:branch)s")
+
 
 def buildVirtualEnv(python, useSystem=False):
     steps = []

--- a/flocker_bb/test/test_steps.py
+++ b/flocker_bb/test/test_steps.py
@@ -75,7 +75,39 @@ class TestMergeForward(sourcesteps.SourceStepMixin, TestCase):
                         env=self.date_env)
             + 0,
             ExpectShell(workdir='wkdir',
-                        command=['git', 'merge-base', 'HEAD', 'FETCH_HEAD'],
+                        command=['git', 'rev-parse', 'FETCH_HEAD'],
+                        env=self.date_env)
+            + ExpectShell.log('stdio', stdout=COMMIT_HASH_NL)
+            + 0,
+        )
+        self.expectOutcome(result=SUCCESS, status_text=['merge', 'forward'])
+        self.expectProperty('lint_revision', COMMIT_HASH)
+        return self.runStep()
+
+    def test_branch_with_merge_target(self):
+        self.buildStep('destroy-the-sun-5000')
+        self.properties.setProperty(
+            'merge_target', 'merge-hash', source='test')
+        self.expectCommands(
+            ExpectShell(workdir='wkdir',
+                        command=['git', 'fetch',
+                                 'git://twisted', 'master'],
+                        env=self.env)
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['git', 'log',
+                                 '--format=%ci', '-n1'],
+                        env=self.env)
+            + ExpectShell.log('stdio', stdout=COMMIT_DATE_NL)
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['git', 'merge',
+                                 '--no-ff', '--no-stat',
+                                 'merge-hash'],
+                        env=self.date_env)
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['git', 'rev-parse', 'merge-hash'],
                         env=self.date_env)
             + ExpectShell.log('stdio', stdout=COMMIT_HASH_NL)
             + 0,
@@ -117,7 +149,7 @@ class TestMergeForward(sourcesteps.SourceStepMixin, TestCase):
                         env=self.date_env)
             + 0,
             ExpectShell(workdir='wkdir',
-                        command=['git', 'merge-base', 'HEAD', 'FETCH_HEAD'],
+                        command=['git', 'rev-parse', 'FETCH_HEAD'],
                         env=self.date_env)
             + ExpectShell.log('stdio', stdout=COMMIT_HASH_NL)
             + 0,


### PR DESCRIPTION
https://clusterhq.atlassian.net/browse/FLOC-1227

Previously, a triggered version would always try to merge against master. Now they will merge against the same version as the triggering build.

This also moves building repository metadata to the master, so multiple versions of packages can be access with yum or apt.