### PR TITLE
Fix phantomjs floc 1264

### DIFF
--- a/slave/phantomjs/Dockerfile
+++ b/slave/phantomjs/Dockerfile
@@ -1,0 +1,26 @@
+FROM fedora:20
+
+RUN yum --assumeyes install \
+	git \
+	&& yum clean all
+
+RUN git clone https://github.com/ariya/phantomjs.git
+
+WORKDIR phantomjs
+
+RUN yum --assumeyes install gcc gcc-c++ make flex bison gperf ruby \
+  openssl-devel freetype-devel fontconfig-devel libicu-devel sqlite-devel \
+  libpng-devel libjpeg-devel \
+  && yum clean all
+
+RUN git checkout 1.9
+
+RUN ./build.sh --confirm
+
+WORKDIR rpm
+
+RUN yum --assumeyes install \
+	rpm-build \
+	&& yum clean all
+
+RUN ./mkrpm.sh phantomjs

--- a/slave/phantomjs/README.txt
+++ b/slave/phantomjs/README.txt
@@ -1,0 +1,9 @@
+Build the Docker image using
+$ docker build .
+
+Run the built image using
+$ docker -it <image-id>
+
+Copy the RPM using:
+$ docker cp <container-id>:/tmp/phantomjs-1.9.8-1.x86_64.rpm .
+

--- a/slave/vagrant/fabfile.py
+++ b/slave/vagrant/fabfile.py
@@ -42,11 +42,6 @@ ARCH=$(uname -m)
 yum install -y https://kojipkgs.fedoraproject.org//packages/kernel/${KV}/${SV}/${ARCH}/kernel-devel-${UNAME_R}.rpm  # noqa
 """)
 
-    run("""
-ARCH=$(uname -m)
-yum install -y https://clusterhq.s3.amazonaws.com/repo/fedora/20/${ARCH}/phantomjs-1.9.8-1.x86_64.rpm  # noqa
-""")
-
     run('yum install -y dkms')
     packages = [
         "https://dl.bintray.com/mitchellh/vagrant/vagrant_1.6.5_x86_64.rpm",
@@ -59,6 +54,7 @@ yum install -y https://clusterhq.s3.amazonaws.com/repo/fedora/20/${ARCH}/phantom
         "python-devel",
         "python-virtualenv",
         "openssl-devel",
+        "https://clusterhq.s3.amazonaws.com/phantomjs-fedora-20/phantomjs-1.9.8-1.x86_64.rpm",  # noqa
     ]
     run("yum install -y " + " ".join(packages))
     run("useradd buildslave")

--- a/slave/vagrant/fabfile.py
+++ b/slave/vagrant/fabfile.py
@@ -42,9 +42,13 @@ ARCH=$(uname -m)
 yum install -y https://kojipkgs.fedoraproject.org//packages/kernel/${KV}/${SV}/${ARCH}/kernel-devel-${UNAME_R}.rpm  # noqa
 """)
 
+    run("""
+ARCH=$(uname -m)
+yum install -y https://clusterhq.s3.amazonaws.com/repo/fedora/20/${ARCH}/phantomjs-1.9.8-1.x86_64.rpm  # noqa
+""")
+
     run('yum install -y dkms')
     packages = [
-        "http://cl.ly/3S1j1X0b372S/download/phantomjs-198-1x86_64.rpm",
         "https://dl.bintray.com/mitchellh/vagrant/vagrant_1.6.5_x86_64.rpm",
         "VirtualBox-4.3.x86_64",
         "https://kojipkgs.fedoraproject.org//packages/buildbot/0.8.10/1.fc22/noarch/buildbot-slave-0.8.10-1.fc22.noarch.rpm",  # noqa

--- a/slave/vagrant/fabfile.py
+++ b/slave/vagrant/fabfile.py
@@ -44,6 +44,7 @@ yum install -y https://kojipkgs.fedoraproject.org//packages/kernel/${KV}/${SV}/$
 
     run('yum install -y dkms')
     packages = [
+        "http://cl.ly/3S1j1X0b372S/download/phantomjs-198-1x86_64.rpm",
         "https://dl.bintray.com/mitchellh/vagrant/vagrant_1.6.5_x86_64.rpm",
         "VirtualBox-4.3.x86_64",
         "https://kojipkgs.fedoraproject.org//packages/buildbot/0.8.10/1.fc22/noarch/buildbot-slave-0.8.10-1.fc22.noarch.rpm",  # noqa


### PR DESCRIPTION
Fixes FLOC-1264

This has been tested with instructions detailed in https://clusterhq.atlassian.net/browse/FLOC-1402 on a Rackspace onmetal server. The test can be seen passing at http://54.213.252.97/builders/flocker%2Facceptance%2Fvagrant%2Ffedora-20/builds/3/steps/trial/logs/stdio.