### PR TITLE
[FLOC-1580] Staging script

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -155,6 +155,20 @@ The tests do not run with root or administrator privileges.
 
 Where ${USERNAME} is a user on the OS X machine, and ${PASSWORD} is the password in ``slaves.osx.passwords`` from the ``config.yml`` used to deploy the BuildBot master at ${MASTER}.
 
+If you do not have root privileges, run the following commands to run a build slave:
+
+.. code:: shell
+
+   # Set MASTER and PASSWORD as above
+   git clone https://github.com/ClusterHQ/build.clusterhq.com.git
+   cd build.clusterhq.com/
+   curl -O https://bootstrap.pypa.io/get-pip.py
+   python get-pip.py --user
+   ~/Library/Python/2.7/bin/pip install --user buildbot-slave==0.8.10 virtualenv==12.0.7
+   ~/Library/Python/2.7/bin/buildslave create-slave ~/flocker-osx "${MASTER}" osx-0 "${PASSWORD}"
+   export PATH=$HOME/Library/python/2.7/bin:$PATH
+   twistd --nodaemon -y flocker-osx/buildbot.tac
+
 Monitoring
 ----------
 

--- a/README.rst
+++ b/README.rst
@@ -57,9 +57,12 @@ Staging changes
 ---------------
 
 Buildbot changes can be tested on a staging machine.
-The docker registry will automatically build an image based on the staging branch, whenever it is updated.
+The Docker registry will automatically build an image based on the ``staging`` branch, whenever it is updated.
 
-Create an Fedora 20 spot instance on EC2 and note the IP of this instance.
+Create a Fedora 20 instance on EC2 and note the IP of this instance.  To start a
+suitable instance, you can run ``python start-aws.py`` if you have `boto` 
+installed and configured to access AWS.
+
 In the following example the IP is 54.191.9.106.
 Set the Security Group of this instance to allow inbound traffic as shown below.
 

--- a/README.rst
+++ b/README.rst
@@ -77,10 +77,10 @@ The Security Group should allow all outbound traffic.
 
 `Install and configure boto <http://boto.readthedocs.org/en/latest/getting_started.html>`_ to allow scriptable access to AWS.
 
-Ensure that the ``aws_region``, ``security_group``, and ``key_name`` variables in the file ``start-aws.py`` are set appropriately.
-
 Run ``python start-aws.py``.
 This command will display the external IP address of the EC2 instance.
+
+Run ``python start-aws.py --help`` to see the available options to this command.
 
 Create staging configuration
 ============================

--- a/README.rst
+++ b/README.rst
@@ -2,14 +2,14 @@ This is the configuration for ClusterHQ's `Buildbot <http://buildbot.net/>`_.
 
 The Buildbot master is deployed as a Docker container running on an AWS EC2 instance.
 
-Most of the slaves are EC2 latent slaves started by the master. Some
-slaves, such as an OS X slave, must be started manually.
+Most of the slaves are EC2 latent slaves started by the master.
+Some slaves, such as an OS X slave, must be started manually.
 
 Buildbot schedulers start builds triggered by a push to any branch in the Flocker repository or by forced builds.
 After a new push to a branch, Buildbot waits a number of seconds before starting a build,
 in case another push arrives shortly afterwards.
 
-All builds are tested as merges against the Flocker ``master`` branch.
+Most builds are tested as merges against the Flocker ``master`` branch.
 
 Install dependencies
 --------------------
@@ -59,6 +59,7 @@ To make the ``staging`` branch the same as a development branch, run the followi
 
 After pushing a change to ``staging``, it takes about 10 minutes for the Docker image build to finish.
 The status is available `here <https://registry.hub.docker.com/u/clusterhq/build.clusterhq.com/builds_history/46090/>`_.
+You will need to a member of the ``clusterhq`` group on Docker Hub in order to click on build id's to see detailed information about build progress or errors.
 
 Create a staging server
 =======================
@@ -110,7 +111,8 @@ Log in to the EC2 instance with the credentials from the ``auth`` section of the
 
 The staging setup is missing the ability to trigger builds in response to Github pushes.
 
-The staging master will start Linux slaves on AWS EC2 automatically.  To start a Mac OS X slave, see below.
+The staging master will start Linux slaves on AWS EC2 automatically.
+To start a Mac OS X slave, see below.
 
 
 Deploy changes to production server
@@ -123,6 +125,7 @@ The Docker registry will automatically build an image based on the ``master`` br
 
 After pushing a change to ``master``, it takes about 10 minutes for the Docker image build to finish.
 The status is available `here <https://registry.hub.docker.com/u/clusterhq/build.clusterhq.com/builds_history/46090/>`_.
+You will need to a member of the ``clusterhq`` group on Docker Hub in order to click on build id's to see detailed information about build progress or errors.
 
 The production instance is accessed using a key from https://github.com/hybridlogic/HybridDeployment (this repository is not publicly available).
 Add the HybridDeployment master key to your authentication agent::
@@ -168,7 +171,7 @@ Slave AMIs
 There are two slave AMIs.
 The images are built by running ``slave/build-images``.
 This will generate images with ``staging-`` prefixes.
-These can be promoted by rnning ``slave/promote-images``.
+These can be promoted by running ``slave/promote-images``.
 
 The images are based on the offical fedora 20 image (``ami-cc8de6fc``) with ``slave/cloud-init-base.sh``.
 Each image uses `slave/cloud-init.sh` with some substitutions as user-data, to start the buildbot.
@@ -207,14 +210,13 @@ The tests do not run with root or administrator privileges.
 
 Where ``${USERNAME}`` is a user on the OS X machine, and ``${PASSWORD}`` is the password in ``slaves.osx.passwords`` from the ``config.yml`` or ``staging.yml`` file used to deploy the BuildBot master on hostname or IP address ``${MASTER}``.
 
-For testing purposes, or if you do not have root privileges, run the following commands to start a build slave:
+For testing purposes, or if you do not have root privileges, run the following commands to start a build slave (set ``MASTER`` and ``PASSWORD`` as above):
 
 .. code:: shell
 
-   # Set MASTER and PASSWORD as above
    curl -O https://bootstrap.pypa.io/get-pip.py
    python get-pip.py --user
-   ~/Library/Python/2.7/bin/pip install --user buildbot-slave==0.8.10 virtualenv==12.0.7
+   ~/Library/Python/2.7/bin/pip install --user buildbot-slave virtualenv
    ~/Library/Python/2.7/bin/buildslave create-slave ~/flocker-osx "${MASTER}" osx-0 "${PASSWORD}"
    export PATH=$HOME/Library/python/2.7/bin:$PATH
    twistd --nodaemon -y flocker-osx/buildbot.tac

--- a/README.rst
+++ b/README.rst
@@ -1,47 +1,139 @@
-This is the configuration for ClusterHQ's `buildbot <http://buildbot.net/>`_.
+This is the configuration for ClusterHQ's `Buildbot <http://buildbot.net/>`_.
 
-The master is deployed on an EC2 instance running in us-west-2, in a docker container.
+The Buildbot master is deployed as a Docker container running on an AWS EC2 instance.
 
-The slaves are EC2 latent slaves started by the master.
+Most of the slaves are EC2 latent slaves started by the master. Some
+slaves, such as an OS X slave, must be started manually.
 
-We use schedulers to start builds, triggered by each push of a commit to a branch and forced builds.
-After each commit is pushed, Buildbot waits a number of seconds before starting a build,
-in case another commit comes in shortly afterwards.
+Buildbot schedulers start builds triggered by a push to any branch in the Flocker repository or by forced builds.
+After a new push to a branch, Buildbot waits a number of seconds before starting a build,
+in case another push arrives shortly afterwards.
 
-All builds are tested as merges against master.
+All builds are tested as merges against the Flocker ``master`` branch.
 
-Deploying changes
------------------
+Install dependencies
+--------------------
 
-The buildbot is deployed from the automated build of the master branch of https://github.com/ClusterHQ/build.clusterhq.com on the docker registry.
-It takes about 10 minutes for the build to occur, after pushing to master;
-the status is available `here <https://registry.hub.docker.com/u/clusterhq/build.clusterhq.com/builds_history/46090/>`_).
+The code uses Fabric to start and manage the Buildbot master.
+
+To install dependencies::
+
+   $ pip install pyyaml
+   $ pip install fabric
+
+
+Create the configuration
+------------------------
+
+The configuration requires secret data that must not be committed to the Github repository.
+The secret data is provided in a file ``config.yml``.
+
+A sample configuration is provided in the file ``config.yml.sample``.
+
+The config file for the ClusterHQ master can be found in the ``config@build.clusterhq.com`` file in LastPass.
+If you have the ``lastpass`` command-line client installed, you can use Fabric to download the current config::
+
+   $ fab getConfig
+
+Fabric passes these variables to Buildbot via a Docker environment variable as JSON.
+
+
+Test changes on staging server
+------------------------------
+
+Changes to the Buildbot master can be tested on a staging machine.
+
+Create a staging Docker image
+=============================
+
+To create a new staging image in the Docker registry, update the ``staging`` branch and push to Github.
+The Docker registry will automatically build an image based on the ``staging`` branch of https://github.com/ClusterHQ/build.clusterhq.com whenever it is updated.
+To make the ``staging`` branch the same as a development branch, run the following commands::
+
+   git checkout staging
+   git pull
+   git reset --hard <other-branch>
+   git reset --soft HEAD@{1}
+   git commit
+   git push
+
+After pushing a change to ``staging``, it takes about 10 minutes for the Docker image build to finish.
+The status is available `here <https://registry.hub.docker.com/u/clusterhq/build.clusterhq.com/builds_history/46090/>`_.
+
+Create a staging server
+=======================
+
+Create an AWS EC2 Security Group to allow inbound traffic as shown below.
+
+.. image:: security-group.png
+   :alt: Custom TCP Rule, TCP Protocol, Port Range 5000, Source Anywhere, 0.0.0.0/0
+         SSH, TCP Protocol, Port Range 22, Source Anywhere, 0.0.0.0/0
+         HTTP, TCP Protocol, Port Range 80, Source Anywhere, 0.0.0.0/0
+         Custom TCP Rule, TCP Protocol, Port Range 9989, Source Anywhere, 0.0.0.0/0
+         All ICMP, ICMP Protocol, Port Range 0-65535, Source Anywhere, 0.0.0.0/0
+
+The Security Group should allow all outbound traffic.
+
+`Install and configure boto <http://boto.readthedocs.org/en/latest/getting_started.html>`_ to allow scriptable access to AWS.
+
+Ensure that the ``aws_region``, ``security_group``, and ``key_name`` variables in the file ``start-aws.py`` are set appropriately.
+
+Run ``python start-aws.py``.
+This command will display the external IP address of the EC2 instance.
+
+Create staging configuration
+============================
+
+Create a file ``staging.yml`` from the ``config.yml``.
+
+Make the following changes to the ``staging.yml`` file:
+
+#. To use the new EC2 instance, change the ``buildmaster.host`` config option to the IP of the EC2 instance.
+
+#. To prevent reports being published to the Flocker Github repository, change the ``github.report_status`` config option to ``False``.
+
+#. To use the staging Docker image, add a ``buildmaster.docker_tag`` config option with the value ``staging``.
+
+
+Start staging server
+====================
+
+To start a Buildbot master on this machine run::
+
+   $ fab start:staging.yml
+
+To update a slave on this machine, run::
+
+   $ fab update:staging.yml
+
+Log in to the EC2 instance with the credentials from the ``auth`` section of the config file.
+
+The staging setup is missing the ability to trigger builds in response to Github pushes.
+
+The staging master will start Linux slaves on AWS EC2 automatically.  To start a Mac OS X slave, see below.
+
+
+Deploy changes to production server
+-----------------------------------
+
+Ensure the dependencies have been installed and configuration created, as described above.
+
+To create a new ``latest`` image in the Docker registry, update the ``master`` branch and push to Github.
+The Docker registry will automatically build an image based on the ``master`` branch of https://github.com/ClusterHQ/build.clusterhq.com whenever it is updated.
+
+After pushing a change to ``master``, it takes about 10 minutes for the Docker image build to finish.
+The status is available `here <https://registry.hub.docker.com/u/clusterhq/build.clusterhq.com/builds_history/46090/>`_.
 
 The production instance is accessed using a key from https://github.com/hybridlogic/HybridDeployment (this repository is not publicly available).
 Add the HybridDeployment master key to your authentication agent::
 
    $ ssh-add /path/to/HybridDeployment/credentials/master_key
 
-Go to a checkout of the build.clusterhq.com repository.
-
-
-Install dependencies::
-
-   $ pip install pyyaml
-   $ pip install fabric
-
-The secrets for the master must be stored in a file ``config.yml`` inside the checkout.
-Fabric passes these variables to buildbot via a docker environment variable as JSON.
-These secrets can be found in the "config@build.clusterhq.com" file in LastPass.
-If you have the lastpass command-line client installed, you can use fabric to download the current config::
-
-   $ fab getConfig
-
 Check if anyone has running builds at http://build.clusterhq.com/buildslaves.
 
-Announce on Zulip's Engineering > buildbot stream that Buildbot will be unavailable for a few minutes.
+Announce on Zulip's ``Engineering > buildbot`` stream that Buildbot will be unavailable for a few minutes.
 
-Update the live Buildbot to the latest image (this may take some time)::
+Update the live Buildbot to the latest Docker image (this may take some time)::
 
    $ fab update
 
@@ -53,50 +145,6 @@ To restart the live Buildbot with the current image::
 
    $ fab restart
 
-Staging changes
----------------
-
-Buildbot changes can be tested on a staging machine.
-The Docker registry will automatically build an image based on the ``staging`` branch, whenever it is updated.
-
-Create a Fedora 20 instance on EC2 and note the IP of this instance.
-
-In the following example the IP is 54.191.9.106.
-Set the Security Group of this instance to allow inbound traffic as shown below.
-
-.. image:: security-group.png
-   :alt: Custom TCP Rule, TCP Protocol, Port Range 5000, Source Anywhere, 0.0.0.0/0
-         SSH, TCP Protocol, Port Range 22, Source Anywhere, 0.0.0.0/0
-         HTTP, TCP Protocol, Port Range 80, Source Anywhere, 0.0.0.0/0
-         Custom TCP Rule, TCP Protocol, Port Range 9989, Source Anywhere, 0.0.0.0/0
-         All ICMP, ICMP Protocol, Port Range 0-65535, Source Anywhere, 0.0.0.0/0
-
-The Security Group should allow all outbound traffic.
-
-To start a suitable instance, run ``python start-aws.py``.
-Install and configure Python package ``boto`` to access AWS.
-Ensure that the security_group and key_name variables in the file ``start-aws.py`` are set appropriately.
-
-Create staging.yml with the config.yml variables from LastPass.
-Change the buildmaster.host config option to the IP of the EC2 instance.
-Change the github.report_status config option to False.
-Add a buildmaster.docker_tag config option, with the value ``staging``.
-
-Follow the "Deploying changes" setup but there is no need to check for running builds or make an announcement on Zulip.
-
-To start a Buildbot slave on this machine run::
-
-   $ fab start:staging.yml
-
-To update a slave on this machine, run::
-
-   $ fab update:staging.yml
-
-Log in to 54.191.9.106 with the credentials from the ``auth`` section of the config file.
-
-The staging setup is missing the ability to trigger builds in response to pushes happening.
-
-The staging master will start Linux slaves on AWS EC2 automatically.  To start a Mac OS X slave, see below.
 
 Wheelhouse
 ----------
@@ -157,7 +205,7 @@ To configure this machine run::
 
 The tests do not run with root or administrator privileges.
 
-Where ${USERNAME} is a user on the OS X machine, and ${PASSWORD} is the password in ``slaves.osx.passwords`` from the ``config.yml`` used to deploy the BuildBot master at ${MASTER}.
+Where ``${USERNAME}`` is a user on the OS X machine, and ``${PASSWORD}`` is the password in ``slaves.osx.passwords`` from the ``config.yml`` or ``staging.yml`` file used to deploy the BuildBot master on hostname or IP address ``${MASTER}``.
 
 For testing purposes, or if you do not have root privileges, run the following commands to start a build slave:
 

--- a/README.rst
+++ b/README.rst
@@ -59,9 +59,7 @@ Staging changes
 Buildbot changes can be tested on a staging machine.
 The Docker registry will automatically build an image based on the ``staging`` branch, whenever it is updated.
 
-Create a Fedora 20 instance on EC2 and note the IP of this instance.  To start a
-suitable instance, you can run ``python start-aws.py`` if you have `boto` 
-installed and configured to access AWS.
+Create a Fedora 20 instance on EC2 and note the IP of this instance.
 
 In the following example the IP is 54.191.9.106.
 Set the Security Group of this instance to allow inbound traffic as shown below.
@@ -74,6 +72,10 @@ Set the Security Group of this instance to allow inbound traffic as shown below.
          All ICMP, ICMP Protocol, Port Range 0-65535, Source Anywhere, 0.0.0.0/0
 
 The Security Group should allow all outbound traffic.
+
+To start a suitable instance, run ``python start-aws.py``.
+Install and configure Python package ``boto`` to access AWS.
+Ensure that the security_group and key_name variables in the file ``start-aws.py`` are set appropriately.
 
 Create staging.yml with the config.yml variables from LastPass.
 Change the buildmaster.host config option to the IP of the EC2 instance.
@@ -93,6 +95,8 @@ To update a slave on this machine, run::
 Log in to 54.191.9.106 with the credentials from the ``auth`` section of the config file.
 
 The staging setup is missing the ability to trigger builds in response to pushes happening.
+
+The staging master will start Linux slaves on AWS EC2 automatically.  To start a Mac OS X slave, see below.
 
 Wheelhouse
 ----------
@@ -155,13 +159,11 @@ The tests do not run with root or administrator privileges.
 
 Where ${USERNAME} is a user on the OS X machine, and ${PASSWORD} is the password in ``slaves.osx.passwords`` from the ``config.yml`` used to deploy the BuildBot master at ${MASTER}.
 
-If you do not have root privileges, run the following commands to run a build slave:
+For testing purposes, or if you do not have root privileges, run the following commands to start a build slave:
 
 .. code:: shell
 
    # Set MASTER and PASSWORD as above
-   git clone https://github.com/ClusterHQ/build.clusterhq.com.git
-   cd build.clusterhq.com/
    curl -O https://bootstrap.pypa.io/get-pip.py
    python get-pip.py --user
    ~/Library/Python/2.7/bin/pip install --user buildbot-slave==0.8.10 virtualenv==12.0.7

--- a/config.yml.sample
+++ b/config.yml.sample
@@ -9,9 +9,10 @@ zulip:
     user: "<zulip user>"
     password: "<zulip password>"
     stream: "BuildBot"
+    critical_stream: "Engineering"
 aws:
-    identifier: "<aws user>"
-    secret_identifier: "<aws password>"
+    identifier: "<aws access key id>"
+    secret_identifier: "<aws secret access key>"
 github:
     token: "<github api token>"
     report_status: True
@@ -23,22 +24,25 @@ slaves:
     fedora:
         ami: "buildslave-fedora-20"
         slaves: 3
-	instance_type: "c3.large"
+        instance_type: "c3.large"
     fedora-zfs-head:
         ami: "buildslave-fedora-20-zfs-head"
         slaves: 1
-	instance_type: "c3.large"
+        instance_type: "c3.large"
     ubuntu-14.04:
         ami: "buildslave-ubuntu-14.04"
         slaves: 1
-	instance_type: "c3.large"
+        instance_type: "c3.large"
     centos-7:
         ami: "buildslave-centos-7"
         slaves: 1
         instance_type: "c3.large"
     fedora-vagrant:
-        passwords: ['password']
-# List of builders whose failures shouldn't be reported.
-failing_builders: []
+        passwords: ['<password>']
     osx:
-        passwords: ['password']
+        passwords: ['<password>']
+# List of builders whose failures should not be reported.  Tests listed here
+# will be reported in a separate section of the Buildbot web page, to indicate
+# that they are expected failures.
+failing_builders: []
+

--- a/start-aws.py
+++ b/start-aws.py
@@ -4,59 +4,59 @@ import time
 import boto.ec2
 
 
-# AWS region
-aws_region = 'us-west-2'
-
-# Name of security group exposing ports for Buildmaster
-security_group = 'Buildbot staging'
-
-# Key name for EC2 host
-key_name = 'hybrid-master'
-
-
+# Usual Fedora 20 image used for most Buildbot infrastructure
 ec2_image = {
     'Fedora-x86_64-20-20140407-sda': 'ami-cc8de6fc'
 }
 
-conn = boto.ec2.connect_to_region(aws_region)
 
-# Buildbot master requires 4Gb diskspace.  Set the EBS root disk (disk1)
-# to be 4Gb instead of default (2Gb).  Also add an ephemeral (4Gb) disk
-# (disk2), not currently used.  If we can easily link /var/lib/docker to
-# /mnt/docker, we don't need to increase the size of the EBS disk, which
-# is slightly cheaper (ephemeral storage is free).
-disk1 = boto.ec2.blockdevicemapping.EBSBlockDeviceType()
-disk1.size = 4
-disk2 = boto.ec2.blockdevicemapping.BlockDeviceType(
-    ephemeral_name='ephemeral0')
-diskmap = boto.ec2.blockdevicemapping.BlockDeviceMapping()
-diskmap['/dev/sda1'] = disk1
-diskmap['/dev/sdb1'] = disk2
+def start_instance(
+        aws_region, key_name, instance_type, security_group, username):
 
+    conn = boto.ec2.connect_to_region(aws_region)
 
-reservation = conn.run_instances(
-    ec2_image['Fedora-x86_64-20-20140407-sda'],
-    key_name=key_name,
-    instance_type='m3.medium',
-    security_groups=[security_group],
-    block_device_map=diskmap)
+    # Buildbot master requires 4Gb diskspace.  Set the EBS root disk (disk1)
+    # to be 4Gb instead of default (2Gb).
+    disk1 = boto.ec2.blockdevicemapping.EBSBlockDeviceType()
+    disk1.size = 4
+    diskmap = boto.ec2.blockdevicemapping.BlockDeviceMapping()
+    diskmap['/dev/sda1'] = disk1
 
-instance = reservation.instances[0]
+    reservation = conn.run_instances(
+        ec2_image['Fedora-x86_64-20-20140407-sda'],
+        key_name=key_name,
+        instance_type=instance_type,
+        security_groups=[security_group],
+        block_device_map=diskmap)
 
-username = os.environ['USER']
-instance_name = '{} BuildBot staging'.format(username)
-conn.create_tags([instance.id], {'Name': instance_name})
+    instance = reservation.instances[0]
 
-state = instance.state
-print 'Instance', state
+    instance_name = '{} BuildBot staging'.format(username)
+    conn.create_tags([instance.id], {'Name': instance_name})
 
-while state != 'running':
-    time.sleep(1)
-    instance.update()
-    new_state = instance.state
-    if new_state != state:
-        state = new_state
-        print 'Instance', state
+    state = instance.state
+    print 'Instance', state
 
-print 'Instance ID:', instance.id
-print 'Instance IP:', instance.ip_address
+    while state != 'running':
+        time.sleep(1)
+        instance.update()
+        new_state = instance.state
+        if new_state != state:
+            state = new_state
+            print 'Instance', state
+
+    print 'Instance ID:', instance.id
+    print 'Instance IP:', instance.ip_address
+
+if __name__ == '__main__':
+    # AWS region
+    aws_region = 'us-west-2'
+
+    # Name of security group exposing ports for Buildmaster
+    security_group = 'Buildbot staging'
+
+    # Key name for EC2 host
+    key_name = 'hybrid-master'
+
+    username = os.environ['USER']
+    start_instance(aws_region, key_name, 'm3.medium', security_group, username)

--- a/start-aws.py
+++ b/start-aws.py
@@ -1,0 +1,48 @@
+import os
+import time
+
+import boto.ec2
+
+ec2_image = {
+    'Fedora-x86_64-20-20140407-sda': 'ami-cc8de6fc'
+}
+
+conn = boto.ec2.connect_to_region('us-west-2')
+
+# Buildbot master requires more than standard 2Gb disk.
+# Also add an ephemeral (4Gb) disk, not currently used.
+# If we link /var/lib/docker to /mnt/docker, we don't need the EBS disk
+disk1 = boto.ec2.blockdevicemapping.EBSBlockDeviceType()
+disk1.size = 4
+disk2 = boto.ec2.blockdevicemapping.BlockDeviceType(ephemeral_name='ephemeral0')
+diskmap = boto.ec2.blockdevicemapping.BlockDeviceMapping()
+diskmap['/dev/sda1'] = disk1
+diskmap['/dev/sdb1'] = disk2
+
+
+reservation = conn.run_instances(
+    ec2_image['Fedora-x86_64-20-20140407-sda'],
+    key_name='hybrid-master',
+    instance_type='m3.medium',
+    security_groups=['Buildbot staging'],
+    block_device_map=diskmap)
+
+instance = reservation.instances[0]
+
+username = os.environ['USER']
+instance_name = '{} BuildBot staging'.format(username)
+conn.create_tags([instance.id], {'Name': instance_name})
+
+state = instance.state
+print 'Instance', state
+
+while state != 'running':
+    time.sleep(1)
+    instance.update()
+    new_state = instance.state
+    if new_state != state:
+        state = new_state
+        print 'Instance', state
+
+print 'Instance ID:', instance.id
+print 'Instance IP:', instance.ip_address

--- a/start-aws.py
+++ b/start-aws.py
@@ -37,6 +37,8 @@ def start_instance(
     state = instance.state
     print 'Instance', state
 
+    # Display state as instance starts up, to keep user informed that
+    # things are happening.
     while state != 'running':
         time.sleep(1)
         instance.update()
@@ -60,22 +62,12 @@ if __name__ == '__main__':
         '--key-name', default='hybrid-master', help='AWS key name')
     parser.add_argument(
         '--instance-type', default='m3.medium', help='AWS instance type')
-    parser.add_argument('--instance-name', help='AWS instance name')
+    parser.add_argument(
+        '--instance-name',
+        default='{} BuildBot staging'.format(os.environ['USER']),
+        help='AWS instance name')
     args = parser.parse_args()
-
-    # AWS region
-    aws_region = args.region
-
-    # Name of security group exposing ports for Buildmaster
-    security_group = args.security_group
-
-    # Key name for EC2 host
-    key_name = 'hybrid-master'
-
-    instance_name = args.instance_name
-    if instance_name is None:
-        instance_name = '{} BuildBot staging'.format(os.environ['USER'])
 
     start_instance(
         args.region, args.key_name, args.instance_type, args.security_group,
-        instance_name)
+        args.instance_name)

--- a/start-aws.py
+++ b/start-aws.py
@@ -20,11 +20,11 @@ ec2_image = {
 
 conn = boto.ec2.connect_to_region(aws_region)
 
-# Buildbot master requires more than standard 4Gb disk.  Set the EBS
-# root disk to be 4Gb instead of default 2Gb.
-# Also add an ephemeral (4Gb) disk, not currently used.  If we link
-# /var/lib/docker to /mnt/docker, we don't need to increase the
-# size of the EBS disk.
+# Buildbot master requires 4Gb diskspace.  Set the EBS root disk (disk1)
+# to be 4Gb instead of default (2Gb).  Also add an ephemeral (4Gb) disk
+# (disk2), not currently used.  If we can easily link /var/lib/docker to
+# /mnt/docker, we don't need to increase the size of the EBS disk, which
+# is slightly cheaper (ephemeral storage is free).
 disk1 = boto.ec2.blockdevicemapping.EBSBlockDeviceType()
 disk1.size = 4
 disk2 = boto.ec2.blockdevicemapping.BlockDeviceType(


### PR DESCRIPTION
The existing instructions for tesing Buildbot changes on a staging server are vague and fail to mention specific requirements (e.g. memory requirements). Create a script to automate the process of starting a staging server, and update the instructions to refer to it.