### PR TITLE
Try running only the tests relevant to the client software.

### DIFF
--- a/flocker_bb/builders/flocker.py
+++ b/flocker_bb/builders/flocker.py
@@ -595,7 +595,13 @@ def getBuilders(slavenames):
         BuilderConfig(name='flocker-osx-10.10',
                       slavenames=slavenames['osx'],
                       category='flocker',
-                      factory=makeFactory(b'python2.7'),
+                      factory=makeFactory(
+                          b'python2.7', tests=[
+                              b'flocker.cli',
+                              b'flocker.common',
+                              b'flocker.ca',
+                          ],
+                      ),
                       nextSlave=idleSlave),
         BuilderConfig(name='flocker-zfs-head',
                       slavenames=slavenames['fedora-zfs-head'],


### PR DESCRIPTION
Fixes https://clusterhq.atlassian.net/browse/FLOC-1560

This restricts the test suite run by the OS X builder.  It runs only the tests for software that is necessary for the CLI - which is the only part of Flocker that needs to work on OS X.

The list of such tests is hard-coded.  It would be better to specify these tests some other way but this is at least a step in the right direction.

Temporarily this branch is staged at http://52.11.7.92/builders/flocker-osx-10.10
