### PR TITLE
[FLOC-1951] Specify acceptance test backends.

### DIFF
--- a/flocker_bb/builders/flocker_vagrant.py
+++ b/flocker_bb/builders/flocker_vagrant.py
@@ -242,6 +242,7 @@ def run_acceptance_tests(configuration):
             Interpolate('%(prop:builddir)s/build/admin/run-acceptance-tests'),
             '--distribution', configuration.distribution,
             '--provider', configuration.provider,
+            '--dataset-backend', configuration.dataset_backend,
             '--branch', flockerBranch,
             '--build-server', buildbotURL,
             '--config-file', Interpolate("%(kw:home)s/acceptance.yml",
@@ -346,6 +347,7 @@ from buildbot.locks import MasterLock
     Attribute('provider'),
     # Vagrant doesn't take a distrubtion.
     Attribute('distribution', default_value=None),
+    Attribute('dataset_backend'),
     Attribute('variants', default_factory=set),
 ])
 class AcceptanceConfiguration(object):
@@ -354,6 +356,7 @@ class AcceptanceConfiguration(object):
 
     :ivar provider: The provider to use.
     :ivar distribution: The distribution to use.
+    :ivar dataset_backend: The dataset backend to use.
     :ivar variants: The variants to use.
     """
 
@@ -362,8 +365,9 @@ class AcceptanceConfiguration(object):
         return '/'.join(
             ['flocker', 'acceptance',
              self.provider,
-             self.distribution]
-            + sorted(self.variants))
+             self.distribution,
+             self.dataset_backend,
+             ] + sorted(self.variants))
 
     @property
     def builder_directory(self):
@@ -379,17 +383,26 @@ class AcceptanceConfiguration(object):
 
 ACCEPTANCE_CONFIGURATIONS = [
     AcceptanceConfiguration(
-        provider='vagrant', distribution='fedora-20'),
+        provider='vagrant', distribution='fedora-20',
+        dataset_backend='zfs'),
     AcceptanceConfiguration(
-        provider='rackspace', distribution='ubuntu-14.04'),
-    AcceptanceConfiguration(
-        provider='rackspace', distribution='centos-7'),
-    AcceptanceConfiguration(
-        provider='rackspace', distribution='centos-7',
-        variants={'docker-head'}),
+        provider='rackspace', distribution='ubuntu-14.04',
+        dataset_backend='loopback'),
     AcceptanceConfiguration(
         provider='rackspace', distribution='centos-7',
-        variants={'zfs-testing'}),
+        dataset_backend='loopback'),
+    AcceptanceConfiguration(
+        provider='rackspace', distribution='ubuntu-14.04',
+        dataset_backend='zfs'),
+    AcceptanceConfiguration(
+        provider='rackspace', distribution='centos-7',
+        dataset_backend='zfs'),
+    AcceptanceConfiguration(
+        provider='rackspace', distribution='centos-7',
+        dataset_backend='loopback', variants={'docker-head'}),
+    AcceptanceConfiguration(
+        provider='rackspace', distribution='centos-7',
+        dataset_backend='zfs', variants={'zfs-testing'}),
 ]
 
 

--- a/flocker_bb/builders/flocker_vagrant.py
+++ b/flocker_bb/builders/flocker_vagrant.py
@@ -382,21 +382,21 @@ class AcceptanceConfiguration(object):
 
 
 ACCEPTANCE_CONFIGURATIONS = [
+    # There is only one vagrant box.
     AcceptanceConfiguration(
         provider='vagrant', distribution='fedora-20',
         dataset_backend='zfs'),
+] + [
     AcceptanceConfiguration(
-        provider='rackspace', distribution='ubuntu-14.04',
-        dataset_backend='loopback'),
-    AcceptanceConfiguration(
-        provider='rackspace', distribution='centos-7',
-        dataset_backend='loopback'),
-    AcceptanceConfiguration(
-        provider='rackspace', distribution='ubuntu-14.04',
-        dataset_backend='zfs'),
-    AcceptanceConfiguration(
-        provider='rackspace', distribution='centos-7',
-        dataset_backend='zfs'),
+        provider=provider, distribution=distribution,
+        dataset_backend=dataset_backend)
+    for provider in ['rackspace']
+    for distribution in ['centos-7', 'ubuntu-14.04']
+    for dataset_backend in ['loopback', 'zfs']
+] + [
+    # flocker currently only know about docker-head and zfs-testing
+    # on centos-7. It isn't worth testing either of these combinations
+    # on multiple cloud providers.
     AcceptanceConfiguration(
         provider='rackspace', distribution='centos-7',
         dataset_backend='loopback', variants={'docker-head'}),


### PR DESCRIPTION
https://clusterhq.atlassian.net/browse/FLOC-1951

This depends on https://github.com/ClusterHQ/flocker/pull/1439

Also, it change the names of all the acceptance tests (losing the history). We could fix this, but I'm not sure if it worth it.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/build.clusterhq.com/91)
<!-- Reviewable:end -->
