### PR TITLE
[FLOC-1693] Read in remote logs written out by run-acceptance-tests.

### DIFF
--- a/flocker_bb/builders/flocker_vagrant.py
+++ b/flocker_bb/builders/flocker_vagrant.py
@@ -271,6 +271,7 @@ def run_acceptance_tests(configuration):
             'sigtermTime': 5*60,
             'logfiles': {
                 'run-acceptance-tests.log': 'run-acceptance-tests.log',
+                'remote_logs.log': 'remote_logs.log',
             },
         },
         tests=[],


### PR DESCRIPTION
This reads in logs created by https://clusterhq.atlassian.net/browse/FLOC-1941, which has been merged.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/build.clusterhq.com/98)
<!-- Reviewable:end -->
