### PR TITLE
Record branch with finished build information

### DIFF
--- a/flocker_bb/monitoring.py
+++ b/flocker_bb/monitoring.py
@@ -105,7 +105,7 @@ class Monitor(StatusReceiverMultiService):
         build.
         """
         slave_name, slave_number = build.getSlavename().rsplit('/', 1)
-        branch_type = getBranchType(getBranch(build))
+        branch_type = getBranchType(getBranch(build)).name
         self.building_counts_gauge.labels(
             builderName, slave_name, slave_number, branch_type).inc()
 
@@ -117,7 +117,7 @@ class Monitor(StatusReceiverMultiService):
         build.
         """
         slave_name, slave_number = build.getSlavename().rsplit('/', 1)
-        branch_type = getBranchType(getBranch(build))
+        branch_type = getBranchType(getBranch(build)).name
         self.building_counts_gauge.labels(
             builderName, slave_name, slave_number, branch_type,
         ).dec()

--- a/flocker_bb/monitoring.py
+++ b/flocker_bb/monitoring.py
@@ -3,7 +3,6 @@ from twisted.application.internet import TimerService
 from twisted.internet.defer import inlineCallbacks, returnValue
 from twisted.python import log
 
-from buildbot.interfaces import IProperties
 from buildbot.status.base import StatusReceiverMultiService
 from buildbot.status.results import Results
 
@@ -25,7 +24,7 @@ class Monitor(StatusReceiverMultiService):
     building_counts_gauge = Gauge(
         'running_builds',
         'Number of running builds',
-        labelnames=['builder', 'slave_class', 'slave_number'],
+        labelnames=['builder', 'slave_class', 'slave_number', 'branch_type'],
         namespace='buildbot',
     )
 
@@ -106,8 +105,9 @@ class Monitor(StatusReceiverMultiService):
         build.
         """
         slave_name, slave_number = build.getSlavename().rsplit('/', 1)
+        branch_type = getBranchType(getBranch(build))
         self.building_counts_gauge.labels(
-            builderName, slave_name, slave_number).inc()
+            builderName, slave_name, slave_number, branch_type).inc()
 
     def buildFinished(self, builderName, build, results):
         """

--- a/flocker_bb/monitoring.py
+++ b/flocker_bb/monitoring.py
@@ -117,10 +117,10 @@ class Monitor(StatusReceiverMultiService):
         build.
         """
         slave_name, slave_number = build.getSlavename().rsplit('/', 1)
-        self.building_counts_gauge.labels(
-            builderName, slave_name, slave_number,
-        ).dec()
         branch_type = getBranchType(getBranch(build))
+        self.building_counts_gauge.labels(
+            builderName, slave_name, slave_number, branch_type,
+        ).dec()
         self.build_counts.labels(
             builderName, slave_name, slave_number, Results[build.getResults()],
             branch_type,

--- a/flocker_bb/steps.py
+++ b/flocker_bb/steps.py
@@ -38,6 +38,34 @@ report_expected_failures_parameter = BooleanParameter(
 )
 
 
+MASTER_BRANCH = 'master'
+RELEASE_BRANCH = 'release'
+MAINTENANCE_BRANCH = 'maintenance'
+DEVELOPMENT_BRANCH = 'development'
+
+
+def getBranchType(branch):
+    """
+    Given a Buildbot branch parameter, return the kind of branch it is.
+
+    This decision is made based on Flocker branch naming conventions.
+
+    :param branch: A string describing a branch. e.g. 'master',
+        'some-feature-FLOC-1234'.
+    :return: One of MASTER_BRANCH, RELEASE_BRANCH, MAINTENANCE_BRANCH, or
+        DEVELOPMENT_BRANCH.
+    """
+    # TODO: Have MergeForward use this, rather than the other way around.
+    if MergeForward._isMaster(branch):
+        return MASTER_BRANCH
+    if MergeForward._isRelease(branch):
+        return RELEASE_BRANCH
+    match = MergeForward._MAINTENANCE_BRANCH_RE.match(branch)
+    if match:
+        return MAINTENANCE_BRANCH
+    return DEVELOPMENT_BRANCH
+
+
 @renderer
 def buildbotURL(build):
     return build.getBuild().build_status.master.status.getBuildbotURL()

--- a/flocker_bb/steps.py
+++ b/flocker_bb/steps.py
@@ -40,10 +40,10 @@ report_expected_failures_parameter = BooleanParameter(
 
 
 class BranchType(Names):
-    MASTER = NamedConstant()
-    RELEASE = NamedConstant()
-    MAINTENANCE = NamedConstant()
-    DEVELOPMENT = NamedConstant()
+    master = NamedConstant()
+    release = NamedConstant()
+    maintenance = NamedConstant()
+    development = NamedConstant()
 
 
 def getBranchType(branch):
@@ -54,18 +54,17 @@ def getBranchType(branch):
 
     :param branch: A string describing a branch. e.g. 'master',
         'some-feature-FLOC-1234'.
-    :return: One of MASTER_BRANCH, RELEASE_BRANCH, MAINTENANCE_BRANCH, or
-        DEVELOPMENT_BRANCH.
+    :return: ``BranchType`` constant.
     """
     # TODO: Have MergeForward use this, rather than the other way around.
     if MergeForward._isMaster(branch):
-        return BranchType.MASTER
+        return BranchType.master
     if MergeForward._isRelease(branch):
-        return BranchType.RELEASE
+        return BranchType.release
     match = MergeForward._MAINTENANCE_BRANCH_RE.match(branch)
     if match:
-        return BranchType.MAINTENANCE
-    return BranchType.DEVELOPMENT
+        return BranchType.maintenance
+    return BranchType.development
 
 
 @renderer

--- a/flocker_bb/steps.py
+++ b/flocker_bb/steps.py
@@ -3,6 +3,7 @@ from collections import Counter
 
 from twisted.internet import defer
 from twisted.python import log
+from twisted.python.constants import NamedConstant, Names
 from twisted.python.filepath import FilePath
 
 from buildbot.process.properties import Interpolate
@@ -38,10 +39,11 @@ report_expected_failures_parameter = BooleanParameter(
 )
 
 
-MASTER_BRANCH = 'master'
-RELEASE_BRANCH = 'release'
-MAINTENANCE_BRANCH = 'maintenance'
-DEVELOPMENT_BRANCH = 'development'
+class BranchType(Names):
+    MASTER = NamedConstant()
+    RELEASE = NamedConstant()
+    MAINTENANCE = NamedConstant()
+    DEVELOPMENT = NamedConstant()
 
 
 def getBranchType(branch):
@@ -57,13 +59,13 @@ def getBranchType(branch):
     """
     # TODO: Have MergeForward use this, rather than the other way around.
     if MergeForward._isMaster(branch):
-        return MASTER_BRANCH
+        return BranchType.MASTER
     if MergeForward._isRelease(branch):
-        return RELEASE_BRANCH
+        return BranchType.RELEASE
     match = MergeForward._MAINTENANCE_BRANCH_RE.match(branch)
     if match:
-        return MAINTENANCE_BRANCH
-    return DEVELOPMENT_BRANCH
+        return BranchType.MAINTENANCE
+    return BranchType.DEVELOPMENT
 
 
 @renderer

--- a/flocker_bb/test/test_steps.py
+++ b/flocker_bb/test/test_steps.py
@@ -4,7 +4,13 @@ from buildbot.status.results import SUCCESS
 from buildbot.test.fake.remotecommand import ExpectShell
 
 from ..steps import (
-    MergeForward)
+    DEVELOPMENT_BRANCH,
+    MAINTENANCE_BRANCH,
+    MASTER_BRANCH,
+    MergeForward,
+    RELEASE_BRANCH,
+    getBranchType,
+)
 
 
 COMMIT_HASH = "deadbeef00000000000000000000000000000000"
@@ -160,3 +166,24 @@ class TestMergeForward(sourcesteps.SourceStepMixin, TestCase):
         self.expectOutcome(result=SUCCESS, status_text=['merge', 'forward'])
         self.expectProperty('lint_revision', COMMIT_HASH)
         return self.runStep()
+
+
+class TestBranchType(TestCase):
+
+    def test_master(self):
+        self.assertEqual(MASTER_BRANCH, getBranchType('master'))
+
+    def test_releaseBranch(self):
+        self.assertEqual(RELEASE_BRANCH, getBranchType('release/foo'))
+
+    def test_releaseTag(self):
+        self.assertEqual(RELEASE_BRANCH, getBranchType('1.0.0'))
+
+    def test_maintenance(self):
+        self.assertEqual(
+            MAINTENANCE_BRANCH,
+            getBranchType('release-maintenance/1.0.0/fix-everything'))
+
+    def test_ordinary(self):
+        self.assertEqual(
+            DEVELOPMENT_BRANCH, getBranchType('fix-a-thing-FLOC-1235'))

--- a/flocker_bb/test/test_steps.py
+++ b/flocker_bb/test/test_steps.py
@@ -168,22 +168,22 @@ class TestMergeForward(sourcesteps.SourceStepMixin, TestCase):
 class TestBranchType(TestCase):
 
     def test_master(self):
-        self.assertEqual(BranchType.MASTER, getBranchType('master'))
+        self.assertEqual(BranchType.master, getBranchType('master'))
 
     def test_releaseBranch(self):
-        self.assertEqual(BranchType.RELEASE, getBranchType('release/foo'))
+        self.assertEqual(BranchType.release, getBranchType('release/foo'))
 
     def test_releaseTag(self):
-        self.assertEqual(BranchType.RELEASE, getBranchType('1.0.0'))
+        self.assertEqual(BranchType.release, getBranchType('1.0.0'))
 
     def test_maintenance(self):
         self.assertEqual(
-            BranchType.MAINTENANCE,
+            BranchType.maintenance,
             getBranchType('release-maintenance/1.0.0/fix-everything'))
 
     def test_ordinary(self):
         self.assertEqual(
-            BranchType.DEVELOPMENT, getBranchType('fix-a-thing-FLOC-1235'))
+            BranchType.development, getBranchType('fix-a-thing-FLOC-1235'))
 
 
 class VersionTests(TestCase):

--- a/flocker_bb/test/test_steps.py
+++ b/flocker_bb/test/test_steps.py
@@ -4,11 +4,8 @@ from buildbot.status.results import SUCCESS
 from buildbot.test.fake.remotecommand import ExpectShell
 
 from ..steps import (
-    DEVELOPMENT_BRANCH,
-    MAINTENANCE_BRANCH,
-    MASTER_BRANCH,
+    BranchType,
     MergeForward,
-    RELEASE_BRANCH,
     getBranchType,
 )
 
@@ -171,19 +168,19 @@ class TestMergeForward(sourcesteps.SourceStepMixin, TestCase):
 class TestBranchType(TestCase):
 
     def test_master(self):
-        self.assertEqual(MASTER_BRANCH, getBranchType('master'))
+        self.assertEqual(BranchType.MASTER, getBranchType('master'))
 
     def test_releaseBranch(self):
-        self.assertEqual(RELEASE_BRANCH, getBranchType('release/foo'))
+        self.assertEqual(BranchType.RELEASE, getBranchType('release/foo'))
 
     def test_releaseTag(self):
-        self.assertEqual(RELEASE_BRANCH, getBranchType('1.0.0'))
+        self.assertEqual(BranchType.RELEASE, getBranchType('1.0.0'))
 
     def test_maintenance(self):
         self.assertEqual(
-            MAINTENANCE_BRANCH,
+            BranchType.MAINTENANCE,
             getBranchType('release-maintenance/1.0.0/fix-everything'))
 
     def test_ordinary(self):
         self.assertEqual(
-            DEVELOPMENT_BRANCH, getBranchType('fix-a-thing-FLOC-1235'))
+            BranchType.DEVELOPMENT, getBranchType('fix-a-thing-FLOC-1235'))

--- a/flocker_bb/test/test_util.py
+++ b/flocker_bb/test/test_util.py
@@ -1,0 +1,45 @@
+from buildbot.sourcestamp import SourceStamp
+from buildbot.status.build import BuildStatus
+from buildbot.status.builder import BuilderStatus
+from twisted.trial.unittest import TestCase
+
+from flocker_bb.util import getBranch
+
+
+class TestGetBranch(TestCase):
+
+    def makeBuildStatus(self, branches):
+        """
+        Make an IBuildStatus that has source stamps for the given branches.
+        """
+        sourceStamps = [SourceStamp(branch=branch) for branch in branches]
+        # This is the bare minimum we can specify to construct a
+        # `BuildStatus`.
+        build = BuildStatus(BuilderStatus(None, None, None, None), None, None)
+        build.setSourceStamps(sourceStamps)
+        return build
+
+    def test_singleBranch(self):
+        """
+        If a build has only one source stamp, getBranch returns its branch.
+        """
+        status = self.makeBuildStatus(['destroy-the-sun-floc-1234'])
+        self.assertEqual('destroy-the-sun-floc-1234', getBranch(status))
+
+    def test_manyBranches(self):
+        """
+        If a build has more than one source stamp, getBranch returns the
+        branch of the first one.
+        """
+        status = self.makeBuildStatus(['destroy-the-sun-floc-1234', 'another'])
+        self.assertEqual('destroy-the-sun-floc-1234', getBranch(status))
+
+    def test_noBranch(self):
+        """
+        If a build has no source stamps, getBranch raises a ValueError.
+
+        This is a pathological case. If buildbot is functioning correctly then
+        it will never happen.
+        """
+        status = self.makeBuildStatus([])
+        self.assertRaises(ValueError, getBranch, status)

--- a/flocker_bb/util.py
+++ b/flocker_bb/util.py
@@ -30,3 +30,20 @@ def timeoutDeferred(reactor, deferred, seconds):
     deferred.addBoth(cancelTimeout)
 
     return delayedTimeOutCall
+
+
+def getBranch(build):
+    """
+    Return the branch for a given build.
+
+    If the build has more than one branch, return the first branch found. If a
+    build has no branches, then raise a ValueError.
+
+    :param build: An ``IBuildStatus``.
+    :return: A branch as a string, e.g. 'master', 'some-feature-FLOC-1234'.
+    """
+    sourceStamps = build.getSourceStamps()
+    try:
+        return (stamp.branch for stamp in sourceStamps).next()
+    except StopIteration:
+        raise ValueError('{} has no source stamps'.format(build))


### PR DESCRIPTION
https://clusterhq.atlassian.net/browse/FLOC-2598
I want to get overall information on how flaky our tests & build process are, so that I can measure the success of our attempts to fix them, and so that we can have some sort of objective measure of when to stop and pursue other priorities.

Probably the easiest way to do this is to measure the rate of failed master builds. 

The first graph at http://metrics.build.clusterhq.com/failures shows the overall rate of failed builds, but it includes builds for branches, many of which we wouldn't expect to pass. 

To be able to filter for just master builds, we need to include a `branch` label in the metrics. This branch does that.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/build.clusterhq.com/114)
<!-- Reviewable:end -->
