### PR TITLE
[FLOC-2659] Manage docker storage

### DIFF
--- a/slave/build-images
+++ b/slave/build-images
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# FLOC-2659 - ...next we'll run this script to build new AWS buildslave AMIs
 
 import sys
 import time

--- a/slave/centos-7/cloud-init-base.sh
+++ b/slave/centos-7/cloud-init-base.sh
@@ -24,20 +24,22 @@ echo ZFS_DKMS_DISABLE_STRIP=y >> /etc/sysconfig/zfs
 
 yum upgrade -y
 yum install -y \
-	git \
-	python-devel \
-	python-tox \
-	python-virtualenv \
-	rpmdevtools \
-	rpmlint \
-	rpm-build \
-	docker-io \
-	libffi-devel \
-	@buildsys-build \
-	openssl-devel \
-	wget \
-	curl \
-	enchant
+        git \
+        python-devel \
+        python-tox \
+        python-virtualenv \
+        rpmdevtools \
+        rpmlint \
+        rpm-build \
+        docker-io \
+        libffi-devel \
+        @buildsys-build \
+        openssl-devel \
+        wget \
+        curl \
+        enchant
+# FLOC-2659 - And we'll need to reconfigure the same Docker config files on Centos-7 here.
+# But in this case we get to do it before docker deamon is started.
 
 yum -y install python-pip
 pip install buildbot-slave

--- a/slave/promote-images
+++ b/slave/promote-images
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
-
+# FLOC-2659 - ...and finally we'll run this script to promote those AMIs so
+# that they can be used when creating on-demand build slaves.
 import sys
 from common import driver, load_manifest
 

--- a/slave/ubuntu-14.04/cloud-init-base.sh
+++ b/slave/ubuntu-14.04/cloud-init-base.sh
@@ -18,6 +18,9 @@ add-apt-repository -y ppa:zfs-native/stable
 # - https://launchpad.net/~james-page/+archive/ubuntu/docker
 add-apt-repository -y ppa:james-page/docker
 
+# FLOC-2659 we're installing an old version of Docker, but I won't do anything about that here.
+# It's been suggested elsewhere that we upgrade to a newer version of Docker
+# (FLOC-1057, FLOC-2524, FLOC-2447)
 
 # Enable debugging for ZFS modules
 echo SPL_DKMS_DISABLE_STRIP=y >> /etc/default/spl
@@ -27,20 +30,85 @@ export DEBIAN_FRONTEND=noninteractive
 apt-get update
 apt-get -y upgrade
 apt-get install -y \
-	buildbot-slave \
-	git \
-	python-dev \
-	python-tox \
-	python-virtualenv \
-	docker.io \
-	libffi-dev \
-	build-essential \
-	wget \
-	curl \
-	yum \
-	libssl-dev \
-	dpkg-dev \
-	enchant
+        buildbot-slave \
+        git \
+        python-dev \
+        python-tox \
+        python-virtualenv \
+        docker.io \
+        libffi-dev \
+        build-essential \
+        wget \
+        curl \
+        yum \
+        libssl-dev \
+        dpkg-dev \
+        enchant
+
+# FLOC-2659 After installing docker.io, I'll need to modify its configuration file.
+
+# The configuration file to modify is:
+# ```
+# root@acceptance-test-richardw-0:~# cat /etc/default/docker.io
+# # Docker Upstart and SysVinit configuration file
+
+# # Customize location of Docker binary (especially for development testing).
+# #DOCKER="/usr/local/bin/docker"
+
+# # Use DOCKER_OPTS to modify the daemon startup options.
+# #DOCKER_OPTS="--dns 8.8.8.8 --dns 8.8.4.4"
+
+# # If you need Docker to use an HTTP proxy, it can also be specified here.
+# #export http_proxy="http://127.0.0.1:3128/"
+
+# # This is also a handy place to tweak where Docker's temporary files go.
+# #export TMPDIR="/mnt/bigdrive/docker-tmp"
+# ```
+
+# And we need to add the following parameters to start docker with a smaller loop back filesystem:
+# https://clusterhq.atlassian.net/browse/FLOC-2628?focusedCommentId=18912&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-18912
+# ```
+#  --storage-opt dm.loopdatasize=1G --storage-opt dm.basesize=1G
+# ```
+# ... one which won't grow larger than the root filesystem
+
+# The default configuration of Docker on our Ubuntu  build slave is
+# ```
+# root@ip-172-31-39-9:~# docker info
+# Containers: 1
+# Images: 87
+# Storage Driver: devicemapper
+#  Pool Name: docker-202:1-273582-pool
+#  Pool Blocksize: 65.54 kB
+#  Data file: /var/lib/docker/devicemapper/devicemapper/data
+#  Metadata file: /var/lib/docker/devicemapper/devicemapper/metadata
+#  Data Space Used: 5.016 GB
+#  Data Space Total: 107.4 GB
+#  Metadata Space Used: 5.915 MB
+#  Metadata Space Total: 2.147 GB
+#  Library Version: 1.02.77 (2012-10-15)
+# ```
+
+# And on acceptance nodes it's slightly different, but probably less important
+# since the nodes are only used for a single test run:
+
+# ```
+# root@acceptance-test-richardw-0:~# docker info
+# Containers: 0
+# Images: 6
+# Storage Driver: aufs
+#  Root Dir: /var/lib/docker/aufs
+#  Dirs: 6
+# Execution Driver: native-0.2
+# Kernel Version: 3.13.0-55-generic
+# Operating System: Ubuntu 14.04.2 LTS
+# ```
+
+# After reconfiguring docker, we'll need to:
+#  * stop it,
+#  * remove the existing /var/lib/docker directory
+#  * restart it
+
 
 # Maybe also linux-source
 


### PR DESCRIPTION
Design for https://clusterhq.atlassian.net/browse/FLOC-2659

I mentioned a few different strategies in the issue.
This branch sketches out how we might reconfigure Docker on our on-demand buildslaves so that its device mapper data file doesn't grow larger than the available space on the root file system.

We might also consider increasing the size of the root partition.

As a followup, we should consider upgrading to a newer version of Docker which is better at cleaning up unused container layers from the device mapper data store.
Or we could configure docker to use a separate block device instead of loopback devices for its data pool, as suggested here:
 * http://www.projectatomic.io/blog/2015/06/notes-on-fedora-centos-and-docker-storage-drivers/