### PR TITLE
[FLOC-2680] Make the slave AMIs larger

### DIFF
--- a/slave/build-images
+++ b/slave/build-images
@@ -20,8 +20,8 @@ def get_size(size_name):
         raise ValueError("Unknown EC2 size.", size_name)
 
 
-def deploy_node(name, base_ami, deploy, username, userdata=None,
-                size="t1.micro", disk_size=8,
+def deploy_node(name, base_ami, deploy, username, userdata,
+                size, disk_size,
                 private_key_file=aws_config['private_key_file'],
                 keyname=aws_config['keyname']):
     """
@@ -79,7 +79,7 @@ def create_image(node, name):
 
 
 def build_image(name, base_ami, deploy, username,
-                userdata=None, size="t1.micro", disk_size=8):
+                userdata, size, disk_size):
     """
     Build an image by deploying a node, and then snapshoting the image.
 

--- a/slave/centos-7/manifest.yml
+++ b/slave/centos-7/manifest.yml
@@ -1,17 +1,19 @@
 images:
 - name: buildslave-centos-7-zfs-head
   base-ami: ami-c7d092f7
-  size: t2.medium
-  username: centos
   deploy:
     file: cloud-init-base.sh
   # Fedora 20 doesn't allow sudo without a terminal by default, so enable it.
   userdata: "#!/bin/sh\nsed -i '/Defaults    requiretty/d' /etc/sudoers"
+  username: centos
+  disk_size: 128
+  size: t2.medium
 
 - name: buildslave-centos-7
   base-ami: buildslave-centos-7-zfs-head
-  size: t2.medium
   deploy:
     script: |-
       sudo yum install -y zfs
   username: centos
+  size: t2.medium
+  disk_size: 128

--- a/slave/centos-7/manifest.yml
+++ b/slave/centos-7/manifest.yml
@@ -15,5 +15,6 @@ images:
     script: |-
       sudo yum install -y zfs
   username: centos
+  userdata: nil
   size: t2.medium
   disk_size: 128

--- a/slave/ubuntu-14.04/manifest.yml
+++ b/slave/ubuntu-14.04/manifest.yml
@@ -3,7 +3,10 @@ images:
   base-ami: ami-818dd9b1
   deploy:
     file: cloud-init-base.sh
+  userdata: nil
   username: ubuntu
+  size: t1.micro
+  disk_size: 128
 
 - name: buildslave-ubuntu-14.04
   base-ami: buildslave-ubuntu-14.04-zfs-head
@@ -16,5 +19,7 @@ images:
       sudo env DEBIAN_FRONTEND=noninteractive
       apt-get -o Dpkg::Options::="--force-confdef"
       -o Dpkg::Options::="--force-confold" install -y zfsutils
+  userdata: nil
   username: ubuntu
   size: c3.large
+  disk_size: 128


### PR DESCRIPTION
Fixes https://clusterhq.atlassian.net/browse/FLOC-2680

This changes the size of the root EBS volume available to instances booted from these AMIs.

I've generated new Ubuntu AMIs using this branch: ami-d1a6a4e1 and ami-65a7a555.  CentOS 7 AMIs can easily be done next.

Manual inspection reveals they indeed have the desired larger root volume.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/build.clusterhq.com/124)
<!-- Reviewable:end -->
