### PR TITLE
[FLOC-2675] Remove uses of doc and release as setup targets.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -157,7 +157,7 @@ Credentials [1]_ for ``s3cmd`` can be configured using ``s3cmd --configure``.
 It can be updated to include available wheels of packages which are in flocker's ``setup.py`` by running the following commands::
 
    python setup.py sdist
-   pip wheel -f dist "Flocker[doc,dev]==$(python setup.py --version)"
+   pip wheel -f dist "Flocker[dev]==$(python setup.py --version)"
    s3cmd put -P -m "Content-Type:application/python+wheel" wheelhouse/*.whl s3://clusterhq-wheelhouse/fedora20-x86_64
    s3cmd ls s3://clusterhq-wheelhouse/fedora20-x86_64/ | sed 's,^.*/\(.*\),<a href="\1">\1</a><br/>,' | s3cmd put -P -m "text/html" - s3://clusterhq-wheelhouse/fedora20-x86_64/index
 

--- a/flocker_bb/builders/flocker.py
+++ b/flocker_bb/builders/flocker.py
@@ -113,7 +113,7 @@ def getFlockerFactory(python):
 def installDependencies():
     return [
         pip("dependencies", ["."]),
-        pip("extras", ["Flocker[doc,dev,release]"]),
+        pip("extras", ["Flocker[dev]"]),
         ]
 
 


### PR DESCRIPTION
Flocker's setup.py no longer has doc and release targets.  Removing
them eliminates the warnings from test logs.

See http://build.clusterhq.com/builders/flocker-centos-7/builds/5710/steps/install-extras/logs/stdio for an example of these warnings (the second and third red lines in the log file).

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/build.clusterhq.com/126)
<!-- Reviewable:end -->
