### PR TITLE
[FLOC-2813] Support Docker client tests

### DIFF
--- a/flocker_bb/builders/flocker_vagrant.py
+++ b/flocker_bb/builders/flocker_vagrant.py
@@ -6,8 +6,7 @@ from buildbot.steps.transfer import StringDownload
 from buildbot.interfaces import IBuildStepFactory
 
 from ..steps import (
-    buildVirtualEnv, virtualenvBinary,
-    getFactory,
+    virtualenvBinary,
     GITHUB,
     buildbotURL,
     MasterWriteFile, asJSON,
@@ -18,7 +17,8 @@ from ..steps import (
     )
 
 # FIXME
-from flocker_bb.builders.flocker import installDependencies, _flockerTests, getFlockerFactory
+from flocker_bb.builders.flocker import (
+    installDependencies, _flockerTests, getFlockerFactory)
 
 
 from characteristic import attributes, Attribute

--- a/flocker_bb/builders/flocker_vagrant.py
+++ b/flocker_bb/builders/flocker_vagrant.py
@@ -224,7 +224,7 @@ def run_client_installation_tests(configuration):
     """
     factory = getFlockerFactory('python2.7')
 
-    factory.addSteps(pip("dependencies", ["."]))
+    factory.addStep(pip("dependencies", ["."]))
 
     factory.addStep(ShellCommand(
         name='test-client-installation',

--- a/flocker_bb/builders/flocker_vagrant.py
+++ b/flocker_bb/builders/flocker_vagrant.py
@@ -405,6 +405,10 @@ class ClientConfiguration(object):
     def builder_directory(self):
         return self.builder_name.replace('/', '-')
 
+    @property
+    def slave_class(self):
+        return 'aws/centos-7'
+
 
 # Dictionary mapping providers for acceptence testing to a list of
 # sets of variants to test on each provider.


### PR DESCRIPTION
When FLOC-2771 is merged, Flocker client tests will no longer be needed for different cloud platforms.  I have removed the provider field from client configurations, and the `provider` and `config-file` flags from the `run-client-tests` command.

For the client configuration, we also only need to install the non-dev requirements.  There were two different `getFlockerFactory` functions (one in `flocker.py` and one in `flocker_vagrant.py`, which did slightly different things. The one in `flocker-vagrant.py` always installed dev dependencies. To allow only installation of non-dev dependencies, and also to avoid future confusion, I have changed the code to use a single function defined in `flocker.py`, which does not install any dependencies.  Hence, all calls now install their dependencies as an additional step.

I also removed the locks for the client tests, as they are no longer required. The locks are used to limit the number of cloud nodes being started.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/build.clusterhq.com/129)
<!-- Reviewable:end -->
