### PR TITLE
[FLOC-2841] Fix staging tag

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -90,11 +90,9 @@ Create a file ``staging.yml`` from the ``config.yml``.
 
 Make the following changes to the ``staging.yml`` file:
 
-#. To use the new EC2 instance, change the ``buildmaster.host`` config option to the IP of the EC2 instance.
+#. To use the new EC2 instance and the Docker image tagged ``staging`` created above, change the ``buildmaster.host`` config option to the IP of the EC2 instance, and add a ``buildmaster.docker_tag`` config option with the value ``staging``.
 
 #. To prevent reports being published to the Flocker Github repository, change the ``github.report_status`` config option to ``False``.
-
-#. To use the staging Docker image, add a ``buildmaster.docker_tag`` config option with the value ``staging``.
 
 
 Start staging server

--- a/README.rst
+++ b/README.rst
@@ -94,6 +94,9 @@ Make the following changes to the ``staging.yml`` file:
 
 #. To prevent reports being published to the Flocker Github repository, change the ``github.report_status`` config option to ``False``.
 
+#. To use the staging Docker image, add a ``buildmaster.docker_tag`` config option with the value ``staging``.
+
+
 Start staging server
 --------------------
 


### PR DESCRIPTION
The staging instructions were recently modified to remove the instructions to set the `docker_tag`, but the commands to create the image were not changed to create an image with a different tag (`latest`).

This means that the staging instructions are broken, as they will ignore the built image, and download the latest master image, not incorporating the desired feature branch changes.

This could be solved by reverting the change (adding the `docker_tag` instructions back in), or by modifying other commands to build an image tagged `latest`.  This PR chooses the former, since tagging a temporary, non-master image as `latest` may be confusing.

Also, combined the instructions for the `buildbot` stanza to avoid the user having to jump back and forth in the `staging.yml` configuration file.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/build.clusterhq.com/131)
<!-- Reviewable:end -->
