### PR TITLE
[FLOC-1057] Upgrade Docker on slave AMIs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -183,24 +183,24 @@ There is usually a numerical suffix indicating which instance of similarly confi
 Slave AMIs
 ----------
 
-There are two slave AMIs.
+There are two slave AMIs per platform.
 The images are built by running ``slave/build-images``.
 This will generate images with ``staging-`` prefixes.
 These can be promoted by running ``slave/promote-images``.
 
-The images are based on the offical fedora 20 image (``ami-cc8de6fc``) with ``slave/cloud-init-base.sh``.
-Each image uses `slave/cloud-init.sh` with some substitutions as user-data, to start the buildbot.
+The images are based on various base OS images available on Amazon.
+The specific image used is defined by the per-platform manifest file.
 
-``fedora-buildslave``
+``<platform>-buildslave``
   is used for most builds, and has all the dependencies installed,
   including the latest release of zfs (or a fixed prerelease, when there are relevant bug fixes).
-  The image is built by running :file:`slave/cloud-init-base.sh` and then installing zfs.
-``fedora-buildslave-zfs-head``
+  The image is built by running :file:`slave/<platform>/cloud-init-base.sh` and then installing zfs.
+``<platform>-buildslave-zfs-head``
   is used to test against the lastest version of zfs.
   It has all the dependencies except zfs installed, and has the latest version of zfs installed when an
-  instance is created.  The image is built by running :file:`slave/cloud-init-base.sh`.
+  instance is created.  The image is built by running :file:`slave/<platform>/cloud-init-base.sh`.
 
-Both images have :file:`salve/cloud-init.sh` run on them at instance creation time.
+Both images have :file:`slave/cloud-init.sh` run on them at instance creation time.
 
 Vagrant Builders
 ----------------

--- a/slave/centos-7/cloud-init-base.sh
+++ b/slave/centos-7/cloud-init-base.sh
@@ -60,7 +60,15 @@ TimeoutStartSec=10min
 EOF
 
 # Install whatever version is newest in the Docker repository.  If you wanted a
-# different version, you should have run the script at a different time.
+# different version, you should have run the script at a different time.  This
+# happens to more or less match a suggestion we give our users for when they
+# install Flocker.  See the install-node document for that.  Users could
+# install Docker in other ways, though, for which we presently have no test
+# coverage.
+#
+# XXX This is duplicated in the ubuntu-14.04 script.  It's hard to share this code
+# because this individual file gets uploaded to the node being initialized so
+# it's not clear where shared "library" code might belong.
 curl https://get.docker.com/ > /tmp/install-docker.sh
 sh /tmp/install-docker.sh
 

--- a/slave/centos-7/cloud-init-base.sh
+++ b/slave/centos-7/cloud-init-base.sh
@@ -45,6 +45,20 @@ yum install -y \
 	curl \
 	enchant
 
+# Raise the startup timeout for the Docker service.  On the first start, it
+# does some initialization work that can be quite time consuming.  The default
+# timeout tends to be too short, startup fails, and the service is marked as
+# failed.  This larger timeout was selected based on observation of how long
+# the initialization seems to take on some arbitrarily selected systems.
+#
+# This comes before installation of Docker because the installation includes
+# a step to enable and start Docker.
+mkdir -p /etc/systemd/system/docker.service.d
+cat >/etc/systemd/system/docker.service.d/01-TimeoutStartSec.conf <<EOF
+[Service]
+TimeoutStartSec=10min
+EOF
+
 # Install whatever version is newest in the Docker repository.  If you wanted a
 # different version, you should have run the script at a different time.
 curl https://get.docker.com/ > /tmp/install-docker.sh

--- a/slave/centos-7/cloud-init-base.sh
+++ b/slave/centos-7/cloud-init-base.sh
@@ -45,23 +45,10 @@ yum install -y \
 	curl \
 	enchant
 
-# Get Docker packages from upstream
-DOCKER_REPO="main"
-LSB_DIST="centos"
-DIST_VERSION="7"
-
-cat >/etc/yum.repos.d/docker-${DOCKER_REPO}.repo <<-EOF
-[docker-${DOCKER_REPO}-repo]
-name=Docker ${DOCKER_REPO} Repository
-baseurl=https://yum.dockerproject.org/repo/${DOCKER_REPO}/${LSB_DIST}/${DIST_VERSION}
-enabled=1
-gpgcheck=1
-gpgkey=https://yum.dockerproject.org/gpg
-EOF
-
 # Install whatever version is newest in the Docker repository.  If you wanted a
 # different version, you should have run the script at a different time.
-yum install -y docker-engine
+curl https://get.docker.com/ > /tmp/install-docker.sh
+sh /tmp/install-docker.sh
 
 # Get the build slave dependencies.
 yum -y install python-pip

--- a/slave/centos-7/cloud-init-base.sh
+++ b/slave/centos-7/cloud-init-base.sh
@@ -1,5 +1,12 @@
 #!/bin/sh
 
+#
+# Initialize a cloud instance with the software required to use the instance as
+# a BuildBot slave.  This is invoked the build-images script.  If versions of
+# software are installed which eventually become outdated, they will continue
+# to be used until the script is re-run.
+#
+
 set -e
 
 # This script is run as a libcloud ScriptDeployment.

--- a/slave/centos-7/cloud-init-base.sh
+++ b/slave/centos-7/cloud-init-base.sh
@@ -38,7 +38,6 @@ yum install -y \
 	rpmdevtools \
 	rpmlint \
 	rpm-build \
-	docker-io \
 	libffi-devel \
 	@buildsys-build \
 	openssl-devel \
@@ -46,6 +45,25 @@ yum install -y \
 	curl \
 	enchant
 
+# Get Docker packages from upstream
+DOCKER_REPO="main"
+LSB_DIST="centos"
+DIST_VERSION="7"
+
+cat >/etc/yum.repos.d/docker-${DOCKER_REPO}.repo <<-EOF
+[docker-${DOCKER_REPO}-repo]
+name=Docker ${DOCKER_REPO} Repository
+baseurl=https://yum.dockerproject.org/repo/${DOCKER_REPO}/${LSB_DIST}/${DIST_VERSION}
+enabled=1
+gpgcheck=1
+gpgkey=https://yum.dockerproject.org/gpg
+EOF
+
+# Install whatever version is newest in the Docker repository.  If you wanted a
+# different version, you should have run the script at a different time.
+yum install -y docker-engine
+
+# Get the build slave dependencies.
 yum -y install python-pip
 pip install buildbot-slave
 

--- a/slave/ubuntu-14.04/cloud-init-base.sh
+++ b/slave/ubuntu-14.04/cloud-init-base.sh
@@ -10,14 +10,7 @@ then
       exit $?
 fi
 
-
 add-apt-repository -y ppa:zfs-native/stable
-
-# Updated docker version. See
-# - https://bugs.launchpad.net/ubuntu/+source/docker.io/+bug/1396572
-# - https://launchpad.net/~james-page/+archive/ubuntu/docker
-add-apt-repository -y ppa:james-page/docker
-
 
 # Enable debugging for ZFS modules
 echo SPL_DKMS_DISABLE_STRIP=y >> /etc/default/spl
@@ -32,7 +25,6 @@ apt-get install -y \
 	python-dev \
 	python-tox \
 	python-virtualenv \
-	docker.io \
 	libffi-dev \
 	build-essential \
 	wget \
@@ -42,7 +34,12 @@ apt-get install -y \
 	dpkg-dev \
 	enchant
 
-# Maybe also linux-source
+# Install whatever version is newest in the Docker repository.  If you wanted a
+# different version, you should have run the script at a different time.
+curl https://get.docker.com/ > /tmp/install-docker.sh
+sh /tmp/install-docker.sh
+
+# XXX Maybe also linux-source
 
 # Despite being a packaging tool, fpm isn't yet packaged for Fedora.
 # See https://github.com/jordansissel/fpm/issues/611

--- a/slave/ubuntu-14.04/cloud-init-base.sh
+++ b/slave/ubuntu-14.04/cloud-init-base.sh
@@ -35,7 +35,15 @@ apt-get install -y \
 	enchant
 
 # Install whatever version is newest in the Docker repository.  If you wanted a
-# different version, you should have run the script at a different time.
+# different version, you should have run the script at a different time.  This
+# happens to more or less match a suggestion we give our users for when they
+# install Flocker.  See the install-node document for that.  Users could
+# install Docker in other ways, though, for which we presently have no test
+# coverage.
+#
+# XXX This is duplicated in the centos-7 script.  It's hard to share this code
+# because this individual file gets uploaded to the node being initialized so
+# it's not clear where shared "library" code might belong.
 curl https://get.docker.com/ > /tmp/install-docker.sh
 sh /tmp/install-docker.sh
 


### PR DESCRIPTION
Fixes https://clusterhq.atlassian.net/browse/FLOC-1057

With this change, Docker can be upgraded by re-generating AMIs.  The version installed by get.docker.com at the time the scripts are run will be installed on the AMI.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/build.clusterhq.com/133)
<!-- Reviewable:end -->
