### PR TITLE
[FLOC-2988] Revert self-referential base AMI change.

### DIFF
--- a/slave/centos-7/manifest.yml
+++ b/slave/centos-7/manifest.yml
@@ -1,6 +1,6 @@
 images:
 - name: buildslave-centos-7-zfs-head
-  base-ami: ami-edffe8dd
+  base-ami: ami-c7d092f7
   deploy:
     file: cloud-init-base.sh
   # Fedora 20 doesn't allow sudo without a terminal by default, so enable it.

--- a/slave/ubuntu-14.04/manifest.yml
+++ b/slave/ubuntu-14.04/manifest.yml
@@ -1,6 +1,6 @@
 images:
 - name: buildslave-ubuntu-14.04-zfs-head
-  base-ami: ami-8b697ebb
+  base-ami: ami-818dd9b1
   deploy:
     file: cloud-init-base.sh
   userdata: nil


### PR DESCRIPTION
https://clusterhq.atlassian.net/browse/FLOC-2988

The base-ami points to the base image used to bulid the AMI. Changing them to
point to the built image means that any new image will be built from the latest
built image, which is what is desired.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/build.clusterhq.com/136)
<!-- Reviewable:end -->
