### PR TITLE
[FLOC-2749] Upgrade pip on buildslaves.

### DIFF
--- a/slave/centos-7/cloud-init-base.sh
+++ b/slave/centos-7/cloud-init-base.sh
@@ -38,7 +38,7 @@ yum install -y \
 	enchant
 
 curl https://bootstrap.pypa.io/get-pip.py | python -
-pip install virtualenv==12.1.1 tox==2.1.1
+pip install virtualenv==13.1.0 tox==2.1.1
 pip install buildbot-slave==0.8.10
 
 # Despite being a packaging tool, fpm isn't yet packaged for Fedora.

--- a/slave/centos-7/cloud-init-base.sh
+++ b/slave/centos-7/cloud-init-base.sh
@@ -26,8 +26,6 @@ yum upgrade -y
 yum install -y \
 	git \
 	python-devel \
-	python-tox \
-	python-virtualenv \
 	rpmdevtools \
 	rpmlint \
 	rpm-build \
@@ -39,8 +37,9 @@ yum install -y \
 	curl \
 	enchant
 
-yum -y install python-pip
-pip install buildbot-slave
+curl https://bootstrap.pypa.io/get-pip.py | python -
+pip install virtualenv==12.1.1 tox==2.1.1
+pip install buildbot-slave==0.8.10
 
 # Despite being a packaging tool, fpm isn't yet packaged for Fedora.
 # See https://github.com/jordansissel/fpm/issues/611
@@ -54,11 +53,3 @@ systemctl start docker
 docker pull busybox
 docker pull openshift/busybox-http-app
 docker pull python:2.7-slim
-
-
-# Configure pip wheelhouse and cache
-mkdir ~root/.pip
-cat > ~root/.pip/pip.conf <<EOF
-[global]
-find-links = file:///var/cache/wheelhouse
-EOF

--- a/slave/osx/fabfile.py
+++ b/slave/osx/fabfile.py
@@ -34,7 +34,7 @@ def install(index, password, master='build.staging.clusterhq.com'):
     with settings(sudo_user='buildslave', shell_env={'HOME': slave_home.path}), cd(slave_home.path):  # noqa
         sudo("curl -O https://bootstrap.pypa.io/get-pip.py")
         sudo("python get-pip.py --user")
-        sudo("~/Library/Python/2.7/bin/pip install --user buildbot-slave==0.8.10 virtualenv==12.1.1")  # noqa
+        sudo("~/Library/Python/2.7/bin/pip install --user buildbot-slave==0.8.10 virtualenv==13.1.0")  # noqa
 
         sudo("~/Library/Python/2.7/bin/buildslave create-slave ~/flocker-osx %(master)s osx/%(index)s %(password)s"  # noqa
              % {'index': index, 'password': password, 'master': master})

--- a/slave/redhat-openstack/fabfile.py
+++ b/slave/redhat-openstack/fabfile.py
@@ -200,7 +200,7 @@ def configure(index, password, master='build.staging.clusterhq.com'):
 
     sudo("curl -O https://bootstrap.pypa.io/get-pip.py")
     sudo("python get-pip.py")
-    sudo("pip install --user buildbot-slave==0.8.10 virtualenv==12.1.1")
+    sudo("pip install --user buildbot-slave==0.8.10 virtualenv==13.1.0")
 
     slashless_name = BUILDSLAVE_NAME.replace("/", "-") + '-' + str(index)
     builddir = 'builddir-' + str(index)

--- a/slave/redhat-openstack/fabfile.py
+++ b/slave/redhat-openstack/fabfile.py
@@ -185,12 +185,9 @@ def configure(index, password, master='build.staging.clusterhq.com'):
     sudo("yum install -y epel-release")
 
     packages = [
-        "https://kojipkgs.fedoraproject.org/packages/buildbot/0.8.10/1.fc22/noarch/buildbot-slave-0.8.10-1.fc22.noarch.rpm",  # noqa
         "git",
         "python",
         "python-devel",
-        "python-tox",
-        "python-virtualenv",
         "libffi-devel",
         "@buildsys-build",
         "openssl-devel",
@@ -200,6 +197,10 @@ def configure(index, password, master='build.staging.clusterhq.com'):
     ]
 
     sudo("yum install -y " + " ".join(packages))
+
+    sudo("curl -O https://bootstrap.pypa.io/get-pip.py")
+    sudo("python get-pip.py")
+    sudo("pip install --user buildbot-slave==0.8.10 virtualenv==12.1.1")
 
     slashless_name = BUILDSLAVE_NAME.replace("/", "-") + '-' + str(index)
     builddir = 'builddir-' + str(index)

--- a/slave/ubuntu-14.04/cloud-init-base.sh
+++ b/slave/ubuntu-14.04/cloud-init-base.sh
@@ -40,7 +40,7 @@ apt-get install -y \
 	enchant
 
 curl https://bootstrap.pypa.io/get-pip.py | python -
-pip install virtualenv==12.1.1 tox==2.1.1
+pip install virtualenv==13.1.0 tox==2.1.1
 pip install buildbot-slave==0.8.10
 
 # Despite being a packaging tool, fpm isn't yet packaged for Fedora.

--- a/slave/ubuntu-14.04/cloud-init-base.sh
+++ b/slave/ubuntu-14.04/cloud-init-base.sh
@@ -27,11 +27,8 @@ export DEBIAN_FRONTEND=noninteractive
 apt-get update
 apt-get -y upgrade
 apt-get install -y \
-	buildbot-slave \
 	git \
 	python-dev \
-	python-tox \
-	python-virtualenv \
 	docker.io \
 	libffi-dev \
 	build-essential \
@@ -42,7 +39,9 @@ apt-get install -y \
 	dpkg-dev \
 	enchant
 
-# Maybe also linux-source
+curl https://bootstrap.pypa.io/get-pip.py | python -
+pip install virtualenv==12.1.1 tox==2.1.1
+pip install buildbot-slave==0.8.10
 
 # Despite being a packaging tool, fpm isn't yet packaged for Fedora.
 # See https://github.com/jordansissel/fpm/issues/611
@@ -53,11 +52,3 @@ gem install fpm
 docker pull busybox:latest
 docker pull openshift/busybox-http-app:latest
 docker pull python:2.7-slim
-
-# Configure pip wheelhouse and cache
-mkdir ~root/.pip
-cat > ~root/.pip/pip.conf <<EOF
-[global]
-find-links = file:///var/cache/wheelhouse
-EOF
-mkdir /var/cache/wheelhouse

--- a/slave/vagrant/fabfile.py
+++ b/slave/vagrant/fabfile.py
@@ -73,6 +73,11 @@ yum install -y https://kojipkgs.fedoraproject.org//packages/kernel/${KV}/${SV}/$
         "https://clusterhq.s3.amazonaws.com/phantomjs-fedora-20/phantomjs-1.9.8-1.x86_64.rpm",  # noqa
     ]
     run("yum install -y " + " ".join(packages))
+
+    sudo("curl -O https://bootstrap.pypa.io/get-pip.py")
+    sudo("python get-pip.py")
+    sudo("pip install --user buildbot-slave==0.8.10 virtualenv==12.1.1")
+
     run("useradd buildslave")
     sudo("buildslave create-slave /home/buildslave/fedora-vagrant %(master)s fedora-20/vagrant/%(index)s %(password)s"  # noqa
          % {'index': index, 'password': password, 'master': master},

--- a/slave/vagrant/fabfile.py
+++ b/slave/vagrant/fabfile.py
@@ -76,7 +76,7 @@ yum install -y https://kojipkgs.fedoraproject.org//packages/kernel/${KV}/${SV}/$
 
     sudo("curl -O https://bootstrap.pypa.io/get-pip.py")
     sudo("python get-pip.py")
-    sudo("pip install --user buildbot-slave==0.8.10 virtualenv==12.1.1")
+    sudo("pip install --user buildbot-slave==0.8.10 virtualenv==13.1.0")
 
     run("useradd buildslave")
     sudo("buildslave create-slave /home/buildslave/fedora-vagrant %(master)s fedora-20/vagrant/%(index)s %(password)s"  # noqa


### PR DESCRIPTION
https://clusterhq.atlassian.net/browse/FLOC-2749

This upgrades the pip used by all the builders to match the one required by buildbot. It does this by upgrading virtualenv to a version that bundles the appropriate pip.

You can see that the appropriate pip is installed [here](http://build.staging.clusterhq.com/builders/flocker-docs/builds/5/steps/install-dependencies/logs/stdio) (for the ubuntu slave) or [here](http://build.staging.clusterhq.com/builders/flocker-centos-7/builds/4/steps/install-dependencies/logs/stdio) (for the centos slave).

I haven't applied the changes to OSX or soyoustart machine yet. (I'll do that once this branch is accepted).

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/build.clusterhq.com/138)
<!-- Reviewable:end -->
