### PR TITLE
[FLOC-3028] Add version to run-client-tests command

### DIFF
--- a/flocker_bb/builders/flocker_vagrant.py
+++ b/flocker_bb/builders/flocker_vagrant.py
@@ -18,7 +18,7 @@ from ..steps import (
 
 # FIXME
 from flocker_bb.builders.flocker import (
-    installDependencies, _flockerTests, getFlockerFactory)
+    check_version, installDependencies, _flockerTests, getFlockerFactory)
 
 
 from characteristic import attributes, Attribute
@@ -226,6 +226,8 @@ def run_client_installation_tests(configuration):
 
     factory.addStep(pip("dependencies", ["."]))
 
+    factory.addSteps(check_version())
+
     factory.addStep(ShellCommand(
         name='test-client-installation',
         description=["testing", "client"],
@@ -235,6 +237,7 @@ def run_client_installation_tests(configuration):
             Interpolate('%(prop:builddir)s/build/admin/run-client-tests'),
             '--distribution', configuration.distribution,
             '--branch', flockerBranch,
+            '--flocker-version', Property('version'),
             '--build-server', buildbotURL,
         ],
         haltOnFailure=True))


### PR DESCRIPTION
The Buildbot client tests do not currently specify the Flocker version when calling the `admin/run-client-tests` script.  This hasn't been a problem in the past, as the client tests simply print out the package version, without checking it.

However, FLOC-2770 will introduce a change to check that the Flocker version in the downloaded package matches the requested Flocker package version.  If the Flocker version is not specified, then the latest installable version is used.

This PR changes Buildbot to specify the Flocker version explicitly in the test, allowing it to pass.

There is a Buildmaster running at http://52.88.231.250 to check the results of this change.

http://build.clusterhq.com/boxes-flocker?branch=check-release-packages-FLOC-2770 demonstrates that client tests fail with the FLOC-2770 change because the current Buildbot does not specify the version. The last line of the stdio log for the two client tests shows that the branch version is being compared against the latest release version.

http://52.88.231.250/boxes-flocker?branch=check-release-packages-FLOC-2770 demonstrates that this is fixed by this PR.

http://52.88.231.250/boxes-flocker demonstrates that this change continues to work with the old client tests.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/build.clusterhq.com/140)
<!-- Reviewable:end -->
