### PR TITLE
[FLOC-3123] Install PyPy on Ubuntu and CentOS buildslaves

### DIFF
--- a/slave/centos-7/cloud-init-base.sh
+++ b/slave/centos-7/cloud-init-base.sh
@@ -43,8 +43,13 @@ yum install -y \
 	curl \
 	enchant
 
+# Download and install PyPy, then symlink it so that "pypy" is available
+wget https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-2.6.1-linux_x86_64-portable.tar.bz2
+tar xf pypy-2.6.1-linux_x86_64-portable.tar.bz2
+ln -s ${PWD}/pypy-2.6.1-linux_x86_64-portable/bin/pypy /usr/local/bin/pypy
+
 curl https://bootstrap.pypa.io/get-pip.py | python -
-# The version of virtualenv here should correspond to the version of 
+# The version of virtualenv here should correspond to the version of
 # pip used by flocker. (See https://virtualenv.pypa.io/en/latest/changes.html to
 # find which version of virtualenv corresponds to which version of pip).
 pip install virtualenv==13.1.0 tox==2.1.1

--- a/slave/ubuntu-14.04/cloud-init-base.sh
+++ b/slave/ubuntu-14.04/cloud-init-base.sh
@@ -22,7 +22,6 @@ apt-get -y upgrade
 apt-get install -y \
 	git \
 	python-dev \
-	pypy-dev \
 	libffi-dev \
 	build-essential \
 	wget \
@@ -31,6 +30,11 @@ apt-get install -y \
 	libssl-dev \
 	dpkg-dev \
 	enchant
+
+# Download and install PyPy, then symlink it so that "pypy" is available
+wget https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-2.6.1-linux_x86_64-portable.tar.bz2
+tar xf pypy-2.6.1-linux_x86_64-portable.tar.bz2
+ln -s ${PWD}/pypy-2.6.1-linux_x86_64-portable/bin/pypy /usr/local/bin/pypy
 
 curl https://bootstrap.pypa.io/get-pip.py | python -
 # The version of virtualenv here should correspond to the version of

--- a/slave/ubuntu-14.04/cloud-init-base.sh
+++ b/slave/ubuntu-14.04/cloud-init-base.sh
@@ -22,6 +22,7 @@ apt-get -y upgrade
 apt-get install -y \
 	git \
 	python-dev \
+	pypy-dev \
 	libffi-dev \
 	build-essential \
 	wget \
@@ -32,7 +33,7 @@ apt-get install -y \
 	enchant
 
 curl https://bootstrap.pypa.io/get-pip.py | python -
-# The version of virtualenv here should correspond to the version of 
+# The version of virtualenv here should correspond to the version of
 # pip used by flocker. (See https://virtualenv.pypa.io/en/latest/changes.html to
 # find which version of virtualenv corresponds to which version of pip).
 pip install virtualenv==13.1.0 tox==2.1.1


### PR DESCRIPTION
Make PyPy available on buildslaves. Add PyPy installation to the scripts that build the slaves.  This does not cause Buildbot to use PyPy. It just allows the Builders to be modified to use PyPy.

Hence, this patch has no effect on existing systems. It is possible, however, to change Builders to use "pypy" as a parameter instead of "python2.7" when creating the virtualenv.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/build.clusterhq.com/142)
<!-- Reviewable:end -->
