### PR TITLE
Quote vagrant floc 2871

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -78,7 +78,7 @@ On the staging server, run the following commands::
    [aws]$ # Change <BRANCH> to the branch of build.clusterhq.com you want
    [aws]$ git checkout <BRANCH>
    [aws]$ sudo docker build --tag clusterhq/build.clusterhq.com:staging .
-   [aws]$ EXISTS=$(docker inspect --format="{}" buildmaster-data 2> /dev/null)
+   [aws]$ EXISTS=$(sudo docker inspect --format="{}" buildmaster-data 2> /dev/null)
    [aws]$ if [ "$EXISTS" == "{}" ]; then sudo docker rm buildmaster-data; fi
    [aws]$ sudo docker run --name buildmaster-data -v /srv/buildmaster/data busybox /bin/true
 

--- a/README.rst
+++ b/README.rst
@@ -81,6 +81,8 @@ On the staging server, run the following commands::
    [aws]$ git checkout <BRANCH>
    [aws]$ sudo docker build --tag clusterhq/build.clusterhq.com:staging .
    # Remove data from any existing builders
+   # If this has been run before:
+   [aws]$ sudo docker rm buildmaster-data
    [aws]$ sudo docker run --name buildmaster-data -v /srv/buildmaster/data busybox /bin/true
 
 Create staging configuration

--- a/README.rst
+++ b/README.rst
@@ -278,10 +278,9 @@ To create a Rackspace OnMetal slave to serve this purpose:
 
 To configure any Fedora 20 or Fedora 21 bare metal machine (e.g. on OnMetal as above)::
 
-   MASTER=<The Buildbot master's hostname or IP address>
-   ONMETAL_IP_ADDRESS=<The IP address of the OnMetal Server>
-   PASSWORD=<The password in "slaves.fedora-20/vagrant.passwords" from the "config.yml" or "staging.yml" file used to deploy the BuildBot master>
    fab -f slave/vagrant/fabfile.py --hosts=root@${ONMETAL_IP_ADDRESS} install:0,${PASSWORD},${MASTER}
+
+Where ``${PASSWORD}`` is the password in ``slaves.fedora-20/vagrant.passwords`` from the ``config.yml`` or ``staging.yml`` file used to deploy the BuildBot master on hostname or IP address ``${MASTER}``
 
 Red Hat Openstack
 -----------------

--- a/README.rst
+++ b/README.rst
@@ -280,7 +280,7 @@ To configure any Fedora 20 or Fedora 21 bare metal machine (e.g. on OnMetal as a
 
    fab -f slave/vagrant/fabfile.py --hosts=root@${ONMETAL_IP_ADDRESS} install:0,${PASSWORD},${MASTER}
 
-Where ``${PASSWORD}`` is the password in ``slaves.fedora-20/vagrant.passwords`` from the ``config.yml`` or ``staging.yml`` file used to deploy the BuildBot master on hostname or IP address ``${MASTER}``
+Where ``${PASSWORD}`` is the password in ``slaves.fedora-20/vagrant.passwords`` from the ``config.yml`` or ``staging.yml`` file used to deploy the BuildBot master on hostname or IP address ``${MASTER}``.
 
 Red Hat Openstack
 -----------------

--- a/README.rst
+++ b/README.rst
@@ -271,9 +271,10 @@ To create a Rackspace OnMetal slave to serve this purpose:
 
 To configure any Fedora 20 or Fedora 21 bare metal machine (e.g. on OnMetal as above)::
 
+   MASTER=<The Buildbot master's hostname or IP address>
+   ONMETAL_IP_ADDRESS=<The IP address of the OnMetal Server>
+   PASSWORD=<The password in "slaves.fedora-20/vagrant.passwords" from the "config.yml" or "staging.yml" file used to deploy the BuildBot master>
    fab -f slave/vagrant/fabfile.py --hosts=root@${ONMETAL_IP_ADDRESS} install:0,${PASSWORD},${MASTER}
-
-Where ``${PASSWORD}`` is the password in ``slaves.fedora-20/vagrant.passwords`` from the ``config.yml`` or ``staging.yml`` file used to deploy the BuildBot master on hostname or IP address ``${MASTER}``.
 
 Red Hat Openstack
 -----------------

--- a/README.rst
+++ b/README.rst
@@ -253,7 +253,7 @@ and the buildslave user has a password-less ssh-key that can log in to it.
 Fedora hardware builders
 ------------------------
 
-The following builders need to run on Fedora 20 on bare metal hardware:
+The following builders need to run on Fedora 20 or Fedora 21 on bare metal hardware:
 
 * flocker-vagrant-dev-box
 * flocker/vagrant/build/tutorial
@@ -265,11 +265,11 @@ To create a Rackspace OnMetal slave to serve this purpose:
 * Log into https://mycloud.rackspace.com,
 * Create Server > OnMetal Server,
 * Give the server an appropriate name,
-* Choose the following options: Image: OnMetal - Fedora 20 (Heisenbug), Flavor: OnMetal Compute, An SSH key you have access to
+* Choose the following options: Image: OnMetal - Fedora 21, Flavor: Compute, An SSH key you have access to
 * Create Server,
 * When this is complete there will be a command to log into the server, e.g. ``ssh root@${ONMETAL_IP_ADDRESS}``.
 
-To configure any Fedora 20 bare metal machine (e.g. on OnMetal as above)::
+To configure any Fedora 20 or Fedora 21 bare metal machine (e.g. on OnMetal as above)::
 
    fab -f slave/vagrant/fabfile.py --hosts=root@${ONMETAL_IP_ADDRESS} install:0,${PASSWORD},${MASTER}
 

--- a/flocker_bb/builders/flocker_vagrant.py
+++ b/flocker_bb/builders/flocker_vagrant.py
@@ -35,6 +35,12 @@ def dotted_version(version):
                                         .replace('+', '.')))
     return render
 
+def quoted_version(version):
+    @renderer
+    def render(props):
+        return (props.render(version)
+                .addCallback(lambda v: quote(version)))
+    return render
 
 def destroy_box(path):
     """
@@ -102,8 +108,8 @@ def buildVagrantBox(box, add=True):
 
     url = Interpolate(
             'https://s3.amazonaws.com/clusterhq-dev-archive/vagrant/'  # noqa
-            '%(kw:box)s/flocker-%(kw:box)s-%(prop:version)s.box',
-            box=box)
+            '%(kw:box)s/flocker-%(kw:box)s-%(kw:quoted_version)s.box',
+            box=box, quoted_version=quoted_version(Property('version')))
 
     steps.append(MasterWriteFile(
         name='write-base-box-metadata',

--- a/flocker_bb/builders/flocker_vagrant.py
+++ b/flocker_bb/builders/flocker_vagrant.py
@@ -61,44 +61,44 @@ def buildVagrantBox(box, add=True):
     @param box: Name of box to build.
     @param add: L{bool} indicating whether the box should be added locally.
     """
-    steps = [
-        SetPropertyFromCommand(
-            command=["python", "setup.py", "--version"],
-            name='check-version',
-            description=['checking', 'version'],
-            descriptionDone=['checking', 'version'],
-            property='version'
-        ),
-        ShellCommand(
-            name='build-base-box',
-            description=['building', 'base', box, 'box'],
-            descriptionDone=['build', 'base', box, 'box'],
-            command=[
-                virtualenvBinary('python'),
-                'admin/build-vagrant-box',
-                '--box', box,
-                '--branch', flockerBranch,
-                '--build-server', buildbotURL,
-            ],
-            haltOnFailure=True,
-        ),
-    ]
-
-    steps.append(ShellCommand(
-        name='upload-base-box',
-        description=['uploading', 'base', box, 'box'],
-        descriptionDone=['upload', 'base', box, 'box'],
-        command=[
-            '/bin/s3cmd',
-            'put',
-            Interpolate(
-                'vagrant/%(kw:box)s/flocker-%(kw:box)s-%(prop:version)s.box',
-                box=box),
-            Interpolate(
-                's3://clusterhq-dev-archive/vagrant/%(kw:box)s/',
-                box=box),
-        ],
-    ))
+    # steps = [
+    #     SetPropertyFromCommand(
+    #         command=["python", "setup.py", "--version"],
+    #         name='check-version',
+    #         description=['checking', 'version'],
+    #         descriptionDone=['checking', 'version'],
+    #         property='version'
+    #     ),
+    #     ShellCommand(
+    #         name='build-base-box',
+    #         description=['building', 'base', box, 'box'],
+    #         descriptionDone=['build', 'base', box, 'box'],
+    #         command=[
+    #             virtualenvBinary('python'),
+    #             'admin/build-vagrant-box',
+    #             '--box', box,
+    #             '--branch', flockerBranch,
+    #             '--build-server', buildbotURL,
+    #         ],
+    #         haltOnFailure=True,
+    #     ),
+    # ]
+    #
+    # steps.append(ShellCommand(
+    #     name='upload-base-box',
+    #     description=['uploading', 'base', box, 'box'],
+    #     descriptionDone=['upload', 'base', box, 'box'],
+    #     command=[
+    #         '/bin/s3cmd',
+    #         'put',
+    #         Interpolate(
+    #             'vagrant/%(kw:box)s/flocker-%(kw:box)s-%(prop:version)s.box',
+    #             box=box),
+    #         Interpolate(
+    #             's3://clusterhq-dev-archive/vagrant/%(kw:box)s/',
+    #             box=box),
+    #     ],
+    # ))
     url = Interpolate(
             'https://s3.amazonaws.com/clusterhq-dev-archive/vagrant/'  # noqa
             '%(kw:box)s/flocker-%(kw:box)s-%(prop:version)s.box',
@@ -116,7 +116,7 @@ def buildVagrantBox(box, add=True):
                 "version": dotted_version(Property('version')),
                 "providers": [{
                     "name": "virtualbox",
-                    "url": quote(url, safe=":/"),
+                    "url": 'example',
                 }]
             }]
         }),
@@ -126,18 +126,18 @@ def buildVagrantBox(box, add=True):
         }
     ))
 
-    if add:
-        steps.append(ShellCommand(
-            name='add-base-box',
-            description=['adding', 'base', box, 'box'],
-            descriptionDone=['add', 'base', box, 'box'],
-            command=['vagrant', 'box', 'add',
-                     '--force',
-                     Interpolate('vagrant/%(kw:box)s/flocker-%(kw:box)s.json',
-                                 box=box)
-                     ],
-            haltOnFailure=True,
-        ))
+    # if add:
+    #     steps.append(ShellCommand(
+    #         name='add-base-box',
+    #         description=['adding', 'base', box, 'box'],
+    #         descriptionDone=['add', 'base', box, 'box'],
+    #         command=['vagrant', 'box', 'add',
+    #                  '--force',
+    #                  Interpolate('vagrant/%(kw:box)s/flocker-%(kw:box)s.json',
+    #                              box=box)
+    #                  ],
+    #         haltOnFailure=True,
+    #     ))
 
     return steps
 

--- a/flocker_bb/builders/flocker_vagrant.py
+++ b/flocker_bb/builders/flocker_vagrant.py
@@ -35,12 +35,14 @@ def dotted_version(version):
                                         .replace('+', '.')))
     return render
 
+
 def quoted_version(version):
     @renderer
     def render(props):
         return (props.render(version)
                 .addCallback(lambda v: quote(v)))
     return render
+
 
 def destroy_box(path):
     """

--- a/flocker_bb/builders/flocker_vagrant.py
+++ b/flocker_bb/builders/flocker_vagrant.py
@@ -109,7 +109,7 @@ def buildVagrantBox(box, add=True):
     url = Interpolate(
             'https://s3.amazonaws.com/clusterhq-dev-archive/vagrant/'  # noqa
             '%(kw:box)s/flocker-%(kw:box)s-%(kw:quoted_version)s.box',
-            box=box, quoted_version=dotted_version(Property('version')))
+            box=box, quoted_version=quoted_version(Property('version')))
 
     steps.append(MasterWriteFile(
         name='write-base-box-metadata',

--- a/flocker_bb/builders/flocker_vagrant.py
+++ b/flocker_bb/builders/flocker_vagrant.py
@@ -39,7 +39,7 @@ def quoted_version(version):
     @renderer
     def render(props):
         return (props.render(version)
-                .addCallback(lambda v: quote(version)))
+                .addCallback(lambda v: quote(v)))
     return render
 
 def destroy_box(path):

--- a/flocker_bb/builders/flocker_vagrant.py
+++ b/flocker_bb/builders/flocker_vagrant.py
@@ -61,44 +61,45 @@ def buildVagrantBox(box, add=True):
     @param box: Name of box to build.
     @param add: L{bool} indicating whether the box should be added locally.
     """
-    # steps = [
-    #     SetPropertyFromCommand(
-    #         command=["python", "setup.py", "--version"],
-    #         name='check-version',
-    #         description=['checking', 'version'],
-    #         descriptionDone=['checking', 'version'],
-    #         property='version'
-    #     ),
-    #     ShellCommand(
-    #         name='build-base-box',
-    #         description=['building', 'base', box, 'box'],
-    #         descriptionDone=['build', 'base', box, 'box'],
-    #         command=[
-    #             virtualenvBinary('python'),
-    #             'admin/build-vagrant-box',
-    #             '--box', box,
-    #             '--branch', flockerBranch,
-    #             '--build-server', buildbotURL,
-    #         ],
-    #         haltOnFailure=True,
-    #     ),
-    # ]
-    #
-    # steps.append(ShellCommand(
-    #     name='upload-base-box',
-    #     description=['uploading', 'base', box, 'box'],
-    #     descriptionDone=['upload', 'base', box, 'box'],
-    #     command=[
-    #         '/bin/s3cmd',
-    #         'put',
-    #         Interpolate(
-    #             'vagrant/%(kw:box)s/flocker-%(kw:box)s-%(prop:version)s.box',
-    #             box=box),
-    #         Interpolate(
-    #             's3://clusterhq-dev-archive/vagrant/%(kw:box)s/',
-    #             box=box),
-    #     ],
-    # ))
+    steps = [
+        SetPropertyFromCommand(
+            command=["python", "setup.py", "--version"],
+            name='check-version',
+            description=['checking', 'version'],
+            descriptionDone=['checking', 'version'],
+            property='version'
+        ),
+        ShellCommand(
+            name='build-base-box',
+            description=['building', 'base', box, 'box'],
+            descriptionDone=['build', 'base', box, 'box'],
+            command=[
+                virtualenvBinary('python'),
+                'admin/build-vagrant-box',
+                '--box', box,
+                '--branch', flockerBranch,
+                '--build-server', buildbotURL,
+            ],
+            haltOnFailure=True,
+        ),
+    ]
+
+    steps.append(ShellCommand(
+        name='upload-base-box',
+        description=['uploading', 'base', box, 'box'],
+        descriptionDone=['upload', 'base', box, 'box'],
+        command=[
+            '/bin/s3cmd',
+            'put',
+            Interpolate(
+                'vagrant/%(kw:box)s/flocker-%(kw:box)s-%(prop:version)s.box',
+                box=box),
+            Interpolate(
+                's3://clusterhq-dev-archive/vagrant/%(kw:box)s/',
+                box=box),
+        ],
+    ))
+
     url = Interpolate(
             'https://s3.amazonaws.com/clusterhq-dev-archive/vagrant/'  # noqa
             '%(kw:box)s/flocker-%(kw:box)s-%(prop:version)s.box',
@@ -116,7 +117,7 @@ def buildVagrantBox(box, add=True):
                 "version": dotted_version(Property('version')),
                 "providers": [{
                     "name": "virtualbox",
-                    "url": 'example',
+                    "url": url,
                 }]
             }]
         }),
@@ -126,18 +127,18 @@ def buildVagrantBox(box, add=True):
         }
     ))
 
-    # if add:
-    #     steps.append(ShellCommand(
-    #         name='add-base-box',
-    #         description=['adding', 'base', box, 'box'],
-    #         descriptionDone=['add', 'base', box, 'box'],
-    #         command=['vagrant', 'box', 'add',
-    #                  '--force',
-    #                  Interpolate('vagrant/%(kw:box)s/flocker-%(kw:box)s.json',
-    #                              box=box)
-    #                  ],
-    #         haltOnFailure=True,
-    #     ))
+    if add:
+        steps.append(ShellCommand(
+            name='add-base-box',
+            description=['adding', 'base', box, 'box'],
+            descriptionDone=['add', 'base', box, 'box'],
+            command=['vagrant', 'box', 'add',
+                     '--force',
+                     Interpolate('vagrant/%(kw:box)s/flocker-%(kw:box)s.json',
+                                 box=box)
+                     ],
+            haltOnFailure=True,
+        ))
 
     return steps
 

--- a/flocker_bb/builders/flocker_vagrant.py
+++ b/flocker_bb/builders/flocker_vagrant.py
@@ -1,3 +1,5 @@
+from urllib import quote
+
 from buildbot.steps.shell import ShellCommand, SetPropertyFromCommand
 from buildbot.process.properties import Interpolate, Property, renderer
 from buildbot.steps.python_twisted import Trial
@@ -97,6 +99,11 @@ def buildVagrantBox(box, add=True):
                 box=box),
         ],
     ))
+    url = Interpolate(
+            'https://s3.amazonaws.com/clusterhq-dev-archive/vagrant/'  # noqa
+            '%(kw:box)s/flocker-%(kw:box)s-%(prop:version)s.box',
+            box=box)
+
     steps.append(MasterWriteFile(
         name='write-base-box-metadata',
         description=['writing', 'base', box, 'box', 'metadata'],
@@ -109,10 +116,7 @@ def buildVagrantBox(box, add=True):
                 "version": dotted_version(Property('version')),
                 "providers": [{
                     "name": "virtualbox",
-                    "url": Interpolate(
-                        'https://s3.amazonaws.com/clusterhq-dev-archive/vagrant/'  # noqa
-                        '%(kw:box)s/flocker-%(kw:box)s-%(prop:version)s.box',
-                        box=box),
+                    "url": quote(url, safe=":/"),
                 }]
             }]
         }),

--- a/flocker_bb/builders/flocker_vagrant.py
+++ b/flocker_bb/builders/flocker_vagrant.py
@@ -109,7 +109,7 @@ def buildVagrantBox(box, add=True):
     url = Interpolate(
             'https://s3.amazonaws.com/clusterhq-dev-archive/vagrant/'  # noqa
             '%(kw:box)s/flocker-%(kw:box)s-%(kw:quoted_version)s.box',
-            box=box, quoted_version=quoted_version(Property('version')))
+            box=box, quoted_version=dotted_version(Property('version')))
 
     steps.append(MasterWriteFile(
         name='write-base-box-metadata',

--- a/flocker_bb/builders/flocker_vagrant.py
+++ b/flocker_bb/builders/flocker_vagrant.py
@@ -39,8 +39,7 @@ def dotted_version(version):
 def quoted_version(version):
     @renderer
     def render(props):
-        return (props.render(version)
-                .addCallback(lambda v: quote(v)))
+        return props.render(version).addCallback(quote)
     return render
 
 


### PR DESCRIPTION
Fixes https://clusterhq.atlassian.net/browse/FLOC-2871

This is how it fails on master on the regular Buildbot:

```
~$ vagrant box add http://build.clusterhq.com/results/vagrant/master/flocker-tutorial.json
==> box: Loading metadata for box 'http://build.clusterhq.com/results/vagrant/master/flocker-tutorial.json'
==> box: Adding box 'clusterhq/flocker-tutorial' (v1.4.0.331.gba3dcc8) for provider: virtualbox
    box: Downloading: https://s3.amazonaws.com/clusterhq-dev-archive/vagrant/tutorial/flocker-tutorial-1.4.0+331.gba3dcc8.box
An error occurred while downloading the remote file. The error
message, if any, is reproduced below. Please fix this error and try
again.

The requested URL returned error: 403 Forbidden
~$
```

A builder is set up (for now) with this new code at 52.89.42.46

```
~$ vagrant box add http://52.89.42.46/results/vagrant/master/flocker-tutorial.json
==> box: Loading metadata for box 'http://52.89.42.46/results/vagrant/master/flocker-tutorial.json'
==> box: Adding box 'clusterhq/flocker-tutorial' (v1.4.0.331.gba3dcc8) for provider: virtualbox
    box: Downloading: https://s3.amazonaws.com/clusterhq-dev-archive/vagrant/tutorial/flocker-tutorial-1.4.0%2B331.gba3dcc8.box
==> box: Successfully added box 'clusterhq/flocker-tutorial' (v1.4.0.331.gba3dcc8) for 'virtualbox'!
~$
```

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/build.clusterhq.com/143)
<!-- Reviewable:end -->
