### PR TITLE
[FLOC-2496] Don't build on every push to flocker

### DIFF
--- a/flocker_bb/builders/flocker.py
+++ b/flocker_bb/builders/flocker.py
@@ -23,6 +23,8 @@ from ..steps import (
     isMasterBranch, isReleaseBranch,
     resultPath, resultURL,
     flockerRevision,
+    getBranchType,
+    BranchType,
     )
 
 # This is where temporary files associated with a build will be dumped.
@@ -660,14 +662,14 @@ BUILDERS = [
 ]
 
 
-def build_automatically(codebase):
+def build_automatically(branch):
     """
     See http://docs.buildbot.net/current/manual/cfg-schedulers.html#id11
 
     Return a bool, whether the branch should be built after a push without
     being forced.
     """
-    return isMasterBranch(codebase) or isReleaseBranch(codebase)
+    return getBranchType(branch) in (BranchType.master, BranchType.release)
 
 
 def getSchedulers():
@@ -678,7 +680,7 @@ def getSchedulers():
             builderNames=BUILDERS,
             # Only build certain branches because problems arise when we build
             # many branches such as queues and request limits.
-            change_filter=ChangeFilter(codebase_fn=build_automatically),
+            change_filter=ChangeFilter(branch_fn=build_automatically),
             codebases={
                 "flocker": {"repository": GITHUB + b"/flocker"},
             },

--- a/flocker_bb/builders/flocker.py
+++ b/flocker_bb/builders/flocker.py
@@ -660,14 +660,14 @@ BUILDERS = [
 ]
 
 
-def build_automatically(branch):
+def build_automatically(codebase):
     """
-    :param branch: The name of a branch.
+    See http://docs.buildbot.net/current/manual/cfg-schedulers.html#id11
 
     Return a bool, whether the branch should be built after a push without
     being forced.
     """
-    return branch == 'master' or branch.startswith('release/')
+    return isMasterBranch(codebase) or isReleaseBranch(codebase)
 
 
 def getSchedulers():
@@ -678,7 +678,7 @@ def getSchedulers():
             builderNames=BUILDERS,
             # Only build certain branches because problems arise when we build
             # many branches such as queues and request limits.
-            change_filter=ChangeFilter(branch_fn=build_automatically),
+            change_filter=ChangeFilter(codebase_fn=build_automatically),
             codebases={
                 "flocker": {"repository": GITHUB + b"/flocker"},
             },

--- a/flocker_bb/builders/flocker.py
+++ b/flocker_bb/builders/flocker.py
@@ -8,6 +8,7 @@ from buildbot.process.properties import Interpolate, Property
 from buildbot.steps.trigger import Trigger
 from buildbot.config import error
 from buildbot.locks import MasterLock
+from buildbot.plugins.util import ChangeFilter
 
 from os import path
 
@@ -659,12 +660,24 @@ BUILDERS = [
 ]
 
 
+def build_automatically(branch):
+    """
+    :param branch: The name of a branch.
+
+    Return a bool, whether the branch should be built after a push without
+    being forced.
+    """
+    return branch == 'master' or branch.startswith('release/')
+
 def getSchedulers():
     return [
         AnyBranchScheduler(
             name="flocker",
             treeStableTimer=5,
             builderNames=BUILDERS,
+            # Only build certain branches because problems arise when we build
+            # many branches such as queues and request limits.
+            change_filter=ChangeFilter(branch_fn=build_automatically),
             codebases={
                 "flocker": {"repository": GITHUB + b"/flocker"},
             },

--- a/flocker_bb/builders/flocker.py
+++ b/flocker_bb/builders/flocker.py
@@ -669,6 +669,7 @@ def build_automatically(branch):
     """
     return branch == 'master' or branch.startswith('release/')
 
+
 def getSchedulers():
     return [
         AnyBranchScheduler(

--- a/flocker_bb/builders/flocker.py
+++ b/flocker_bb/builders/flocker.py
@@ -8,7 +8,7 @@ from buildbot.process.properties import Interpolate, Property
 from buildbot.steps.trigger import Trigger
 from buildbot.config import error
 from buildbot.locks import MasterLock
-from buildbot.plugins.util import ChangeFilter
+from buildbot.changes.filter import ChangeFilter
 
 from os import path
 


### PR DESCRIPTION
Fixes https://clusterhq.atlassian.net/browse/FLOC-2496

This has been tested by setting up a test buildbot at http://52.89.42.46, and adding a GitHub webhook for Flocker pushes (as the main buildmaster has). With this buildbot on the master branch, all pushes to an experimental branch triggered builds. With this buildbot on this branch pushes to an experimental branch did not trigger builds, but pushes to a branch named "release/EXPERIMENTAL-BRANCH" triggered builds. I did not push to Flocker's master and have deemed that case sufficiently trivial to not need testing (and I hope you agree).

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/build.clusterhq.com/145)
<!-- Reviewable:end -->
