### PR TITLE
[FLOC-3246] Only one run AWS test at a time

### DIFF
--- a/flocker_bb/builders/flocker_vagrant.py
+++ b/flocker_bb/builders/flocker_vagrant.py
@@ -502,8 +502,9 @@ ACCEPTANCE_CONFIGURATIONS = [
 # 256000M available ram, 8192M per node, 2 nodes per test
 # We allocate slightly less to avoid using all the RAM.
 rackspace_lock = MasterLock("rackspace-lock", maxCount=8)
-# We can have up to 30 instances, 2 per test, with some slack.
-aws_lock = MasterLock('aws-lock', maxCount=6)
+# AWS tests are (probably) doing too many requests for us to run them in
+# parallel. See FLOC-3246.
+aws_lock = MasterLock('aws-lock', maxCount=1)
 ACCEPTANCE_LOCKS = {
     'rackspace': [rackspace_lock.access("counting")],
     'aws': [aws_lock.access("counting")],


### PR DESCRIPTION
Will possibly cause fewer tests to fail. 

If that's the case, then we can gradually ramp up parallelism.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/build.clusterhq.com/146)
<!-- Reviewable:end -->
